### PR TITLE
Cellml2gotran

### DIFF
--- a/src/gotranx/__init__.py
+++ b/src/gotranx/__init__.py
@@ -13,6 +13,7 @@ from . import units
 from . import sympytools
 from . import schemes
 from . import templates
+from . import cellml
 from .load import load_ode
 from .ode import ODE
 from .ode_component import Component
@@ -46,4 +47,5 @@ __all__ = [
     "sympytools",
     "schemes",
     "templates",
+    "cellml",
 ]

--- a/src/gotranx/cellml/__init__.py
+++ b/src/gotranx/cellml/__init__.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+from typing import Any
+from .cellml import CellMLParser
+
+
+def cellml_to_gotran(filename: Path | str, params: dict[str, Any] | None = None) -> str:
+    """Convert a cellml file to gotran code
+
+    Parameters
+    ----------
+    input_filename : Path or str
+        The path to the cellml file
+    params : dict[str, Any], optional
+        Parameters to pass to the parser, by default None
+
+    Returns
+    -------
+    str
+        The gotran code
+    """
+    parser = CellMLParser(filename, params=params)
+    return parser.to_gotran()

--- a/src/gotranx/cellml/__init__.py
+++ b/src/gotranx/cellml/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 from typing import Any
 from .cellml import CellMLParser

--- a/src/gotranx/cellml/cellml.py
+++ b/src/gotranx/cellml/cellml.py
@@ -408,8 +408,6 @@ class CellMLParser(object):
         return {
             "change_state_names": [],
             "grouping": "encapsulation",
-            "use_sympy_integers": False,
-            "strip_parent_name": True,
         }
 
     def __init__(self, model_source, params=None, targets=None):
@@ -446,7 +444,7 @@ class CellMLParser(object):
         self.model_source = model_source
         self.name = self.cellml.attrib["name"]
         logger.info(f"Parsing CellML model: {self.name}")
-        self.mathmlparser = MathMLBaseParser(self._params["use_sympy_integers"])
+        self.mathmlparser = MathMLBaseParser()
         self.cellml_namespace = self.cellml.tag.split("}")[0] + "}"
         self.parse_units()
         self.components = self.parse_components(targets)
@@ -1440,7 +1438,7 @@ class CellMLParser(object):
                 comp.parent = components[parent_name]
 
                 # If parent name in child name, reduce child name length
-                if self._params["strip_parent_name"] and parent_name in comp.name:
+                if parent_name in comp.name:
                     old_name = comp.name
                     new_name = old_name.replace(parent_name, "").strip("_")
                     if new_name not in all_component_names:

--- a/src/gotranx/cellml/cellml.py
+++ b/src/gotranx/cellml/cellml.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # Copyright (C) 2011-2012 Johan Hake
 #
 # This file is part of Gotran.

--- a/src/gotranx/cellml/cellml.py
+++ b/src/gotranx/cellml/cellml.py
@@ -1,0 +1,1709 @@
+# Copyright (C) 2011-2012 Johan Hake
+#
+# This file is part of Gotran.
+#
+# Gotran is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Gotran is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Gotran. If not, see <http://www.gnu.org/licenses/>.
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from collections import deque
+from collections import OrderedDict
+from functools import cmp_to_key
+from pathlib import Path
+from xml.etree import ElementTree
+import structlog
+
+logger = structlog.getLogger(__name__)
+
+from .mathml import MathMLBaseParser
+
+
+def cmp(a, b):
+    return (a > b) - (a < b)
+
+
+_all_keywords: list[str] = []
+
+
+# Local imports
+
+__all__ = ["CellMLParser"]
+
+si_unit_map = {
+    "ampere": "A",
+    "becquerel": "Bq",
+    "candela": "cd",
+    "celsius": "gradC",
+    "coulomb": "C",
+    "dimensionless": "1",
+    "farad": "F",
+    "gram": "g",
+    "gray": "Gy",
+    "henry": "H",
+    "hertz": "Hz",
+    "joule": "J",
+    "katal": "kat",
+    "kelvin": "K",
+    "kilogram": "kg",
+    "liter": "l",
+    "litre": "l",
+    "molar": "M",
+    "lumen": "lm",
+    "lux": "lx",
+    "meter": "m",
+    "metre": "m",
+    "mole": "mole",
+    "newton": "N",
+    "ohm": "Omega",
+    "pascal": "Pa",
+    "radian": "rad",
+    "second": "s",
+    "siemens": "S",
+    "sievert": "Sv",
+    "steradian": "sr",
+    "tesla": "T",
+    "volt": "V",
+    "watt": "W",
+    "weber": "Wb",
+}
+
+prefix_map = {
+    "deca": "da",
+    "hecto": "h",
+    "kilo": "k",
+    "mega": "M",
+    "giga": "G",
+    "tera": "T",
+    "peta": "P",
+    "exa": "E",
+    "zetta": "Z",
+    "yotta": "Y",
+    "deci": "d",
+    "centi": "c",
+    "milli": "m",
+    "micro": "u",
+    "nano": "n",
+    "pico": "p",
+    "femto": "f",
+    "atto": "a",
+    "zepto": "z",
+    "yocto": "y",
+    None: "",
+    "-3": "m",
+}
+
+ui = "UNINITIALIZED"
+
+
+class Equation:
+    """
+    Class for holding information about an Equation
+    """
+
+    def __init__(self, name, expr, used_variables):
+        self.name = name
+        self.expr = expr
+        self.used_variables = used_variables
+        self.dependent_equations = []
+        self.component = None
+
+    def check_dependencies(self, equation):
+        """
+        Check Equation dependencies
+        """
+        assert isinstance(equation, Equation)
+
+        if equation.name in self.used_variables:
+            self.dependent_equations.append(equation)
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return f"Equation({self.name} = {''.join(self.expr)})"
+
+    def __eq__(self, other):
+        if not isinstance(other, Equation):
+            return False
+        return other.name == self.name and other.component == self.component
+
+    def __hash__(self):
+        return hash(self.name + self.component.name)
+
+
+class Component:
+    """
+    Class for holding information about a CellML Component
+    """
+
+    def __init__(self, name, variables, equations, state_variables=None):
+        self.name = name
+
+        self.variable_info = {}
+
+        self.state_variables = OrderedDict(
+            (state, variables.pop(state, None)) for state in state_variables
+        )
+
+        for state, _info in list(self.state_variables.items()):
+            self.variable_info[state] = _info
+            self.variable_info["type"] = "state_variable"
+
+        self.parameters = OrderedDict(
+            (name, _info) for name, _info in list(variables.items()) if _info["init"] is not None
+        )
+
+        for param, _info in list(self.parameters.items()):
+            self.variable_info[param] = _info
+            self.variable_info["type"] = "parameter"
+
+        self.derivatives = state_variables
+
+        self.parent = None
+        self.children = []
+
+        self.dependencies = OrderedDict()
+        self.used_in = OrderedDict()
+
+        # Store equations
+        self.sort_and_store_equations(equations)
+
+        # Extract info
+        dummy = dict(init=None, unit="1", private=True)
+        for eq in self.equations:
+            self.variable_info[eq.name] = variables.get(eq.name, dummy)
+            self.variable_info[eq.name]["type"] = "equation"
+
+        # Get used variables
+        self.used_variables = set()
+        for equation in self.equations:
+            self.used_variables.update(equation.used_variables)
+
+        # Remove dependencies on names defined by component
+        self.used_variables.difference_update(equation.name for equation in self.equations)
+
+        self.used_variables.difference_update(name for name in self.parameters)
+
+        self.used_variables.difference_update(name for name in self.state_variables)
+
+    def sort_and_store_equations(self, equations):
+        # Check if reserved name for state derivativeis is used as equation
+        # name
+        derivative_names = [f"d{der}_dt" for der in self.derivatives]
+
+        for eq in equations[:]:
+            if eq.name in derivative_names and len(eq.expr) == 1 and eq.expr[0] == eq.name:
+                equations.remove(eq)
+
+        # Check internal dependencies
+        for eq0 in equations:
+            eq0.dependent_equations = []
+
+            # Store component
+            eq0.component = self
+            for eq1 in equations:
+                if eq0 == eq1:
+                    continue
+                eq0.check_dependencies(eq1)
+
+        sorted_equations = []
+        while equations:
+            equation = equations.pop(0)
+            if any(dep in equations for dep in equation.dependent_equations):
+                equations.append(equation)
+            else:
+                sorted_equations.append(equation)
+
+        # Store the sorted equations
+        self.equations = sorted_equations
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __str__(self):
+        return self.name + f"<{len(self.state_variables)}>"
+
+    def __repr__(self):
+        return f"Component<{self.name}, {len(self.state_variables)}>"
+
+    def __eq__(self, other):
+        if not isinstance(other, Component):
+            return False
+
+        return other.name == self.name
+
+    def check_dependencies(self, component):
+        """
+        Check components dependencies
+        """
+        assert isinstance(component, Component)
+
+        if any(equation.name in self.used_variables for equation in component.equations):
+            dep_equations = [
+                equation for equation in component.equations if equation.name in self.used_variables
+            ]
+
+            # Register mutual dependencies
+            self.dependencies[component] = dep_equations
+            component.used_in[self] = dep_equations
+
+            # Add logics for dependencies of all Equations.
+            for other_equation in component.equations:
+                for equation in self.equations:
+                    if other_equation.name in equation.used_variables:
+                        equation.dependent_equations.append(other_equation)
+
+    def change_parameter_name(self, oldname, newname=None):
+        """
+        Change the name of a parameter
+        Assume the name is only used locally within this component
+        """
+        assert oldname in self.parameters
+
+        # If no newname is give we pick one based on the component name
+        if newname is None:
+            newname = oldname + "_" + self.name.split("_")[0]
+
+        logger.warning(
+            "Locally change parameter name '{0}' to '{1}' in " "component '{2}'.".format(
+                oldname, newname, self.name
+            ),
+        )
+
+        # Update parameters
+        self.parameters = OrderedDict(
+            (newname if name == oldname else name, value)
+            for name, value in list(self.parameters.items())
+        )
+
+        # Update equations
+        for eqn in self.equations:
+            while oldname in eqn.expr:
+                eqn.expr[eqn.expr.index(oldname)] = newname
+
+        return newname
+
+    def change_state_name(self, oldname, newname=None):
+        """
+        Change the name of a state
+        Assume the name is only used locally within this component
+        """
+        assert oldname in self.state_variables
+
+        # If no newname is give we pick one based on the component name
+        if newname is None:
+            newname = oldname + "_" + self.name.split("_")[0]
+
+        logger.warning(
+            "Locally change state name '{0}' to '{1}' in component " "'{2}'.".format(
+                oldname, newname, self.name
+            ),
+        )
+
+        # Update parameters
+        self.state_variables = OrderedDict(
+            (newname if name == oldname else name, value)
+            for name, value in list(self.state_variables.items())
+        )
+
+        oldder = self.derivatives[oldname]
+        newder = oldder.replace(oldname, newname)
+        self.derivatives = OrderedDict(
+            (newname if name == oldname else name, newder if value == oldder else value)
+            for name, value in list(self.derivatives.items())
+        )
+        # Update equations
+        for eqn in self.equations:
+            while oldname in eqn.expr:
+                eqn.expr[eqn.expr.index(oldname)] = newname
+            while oldder in eqn.expr:
+                eqn.expr[eqn.expr.index(oldder)] = newder
+            if oldder == eqn.name:
+                eqn.name = newder
+
+        # Update derivative equation
+        old_eq_name = f"d{oldname}_dt"
+        new_eq_name = f"d{newname}_dt"
+        self.variable_info[new_eq_name] = self.variable_info.pop(
+            old_eq_name,
+            dict(init=None, unit="1", private=True, type="equation"),
+        )
+
+        return newname
+
+    def change_equation_name(self, oldname, newname=None):
+        assert (
+            oldname in self.variable_info and self.variable_info[oldname].get("type") == "equation"
+        )
+
+        # If no newname is give we pick one based on the component name
+        if newname is None:
+            newname = oldname + "_" + self.name.split("_")[0]
+
+        logger.warning(
+            "Locally change equation name '{0}' to '{1}' in " "component '{2}'.".format(
+                oldname, newname, self.name
+            ),
+        )
+
+        # Go through all equations and change the name used locally
+        for ind, eqn in enumerate(self.equations[:]):
+            while oldname in eqn.expr:
+                eqn.expr[eqn.expr.index(oldname)] = newname
+
+            # Update the actuall equation
+            if eqn.name == oldname:
+                eqn.name = newname
+                self.equations[ind] = eqn
+
+        # Update meta info
+        self.variable_info[newname] = self.variable_info.pop(oldname)
+
+        return newname
+
+    def change_variable_name(self, oldname, newname=None):
+        if oldname not in self.variable_info:
+            logger.error(
+                "Cannot change variable name. {0} is not a variable " "in component {1}".format(
+                    oldname, self.name
+                ),
+            )
+            return
+
+        vartype = self.variable_info[oldname]["type"]
+
+        assert vartype in ["state_variable", "parameter", "equation"]
+
+        if vartype == "state_variable":
+            return self.change_state_name(oldname, newname)
+        if vartype == "parameter":
+            return self.change_parameter_name(oldname, newname)
+
+        return self.change_equation_name(oldname, newname)
+
+
+class CellMLParser(object):
+    """
+    This module parses a CellML XML-file and converts it to PyCC code
+    """
+
+    @staticmethod
+    def default_parameters():
+        # Get the default parameters from the global parameters object
+        return {
+            "change_state_names": [],
+            "grouping": "encapsulation",
+            "use_sympy_integers": False,
+            "strip_parent_name": True,
+        }
+
+    def __init__(self, model_source, params=None, targets=None):
+        """
+        Arguments:
+        ----------
+
+        model_source: str
+            Path or url to CellML file
+        params : dict
+            A dict with parameters for the
+        targets : list, dict (optional)
+            Components of the model to parse
+        """
+
+        targets = targets or []
+        params = params or {}
+        assert isinstance(model_source, (str, Path))
+        assert isinstance(targets, (list, dict))
+        self._params = self.default_parameters()
+        self._params.update(params)
+
+        # Open file or url
+        try:
+            with open(model_source, "r") as fp:
+                self.cellml = ElementTree.parse(fp).getroot()
+        except IOError:
+            try:
+                fp = urllib.request.urlopen(model_source)
+                self.cellml = ElementTree.parse(fp).getroot()
+            except Exception:
+                logger.error("ERROR: Unable to open " + model_source)
+
+        self.model_source = model_source
+        self.name = self.cellml.attrib["name"]
+        logger.info(f"Parsing CellML model: {self.name}")
+        self.mathmlparser = MathMLBaseParser(self._params["use_sympy_integers"])
+        self.cellml_namespace = self.cellml.tag.split("}")[0] + "}"
+        self.parse_units()
+        self.components = self.parse_components(targets)
+
+        self.documentation = self.parse_documentation()
+
+    def parse_documentation(self):
+        """
+        Parse the documentation of the article
+        """
+        namespace = "{http://cellml.org/tmp-documentation}"
+        article = self.cellml.iter(namespace + "article")
+
+        try:
+            article = list(article)[0]
+        except IndexError:
+            return ""
+
+        articleinfo = list(article.iter(namespace + "articleinfo"))[0]
+
+        # Get title
+        if articleinfo and articleinfo.iter(namespace + "title"):
+            title = list(articleinfo.iter(namespace + "title"))[0].text
+        else:
+            title = ""
+
+        # Get model structure comments
+        for child in list(article):
+            if child.attrib.get("id") == "sec_structure":
+                content = []
+                for par in child.iter(namespace + "para"):
+                    # Get lines
+                    splitted_line = deque(
+                        ("".join(text.strip() for text in par.itertext())).split(" "),
+                    )
+
+                    # Cut them in lines which are not longer than 80 characters
+                    ret_lines = []
+                    while splitted_line:
+                        line_stumps = []
+                        line_length = 0
+                        while splitted_line and (line_length + len(splitted_line[0]) < 80):
+                            line_stumps.append(splitted_line.popleft())
+                            line_length += len(line_stumps[-1]) + 1
+                        ret_lines.append(" ".join(line_stumps))
+
+                    content.extend(ret_lines)
+                    content.append("\n")
+
+                # Clean up content
+                content = (
+                    ("\n".join(cont.strip() for cont in content))
+                    .replace("  ", " ")
+                    .replace(" .", ".")
+                    .replace(" ,", ",")
+                )
+                break
+        else:
+            content = ""
+
+        if title or content:
+            return f"{title}\n\n{content}"
+
+        return ""
+
+    def _gettag(self, node):
+        """
+        Splits off the namespace part from name, and returns the rest, the tag
+        """
+        return "".join(node.tag.split("}")[1:])
+
+    def parse_units(self):
+        """
+        Parse any declared units in the model
+        """
+        collected_units = OrderedDict()
+        unit_map = si_unit_map.copy()
+
+        # Extend unit_map
+        for cellml_pref, pref in list(prefix_map.items()):
+            if cellml_pref:
+                unit_map[cellml_pref + "molar"] = pref + "M"
+                collected_units[cellml_pref + "molar"] = {pref + "M": (pref + "M", "1")}
+
+        parsed_twice = []
+        all_units = deque(self.get_iterator("units"))
+        while all_units:
+            units = all_units.popleft()
+            unit_name = units.attrib["name"]
+
+            if unit_name in unit_map:
+                continue
+
+            collected_parts = OrderedDict()
+            for unit in list(units):
+                if unit.attrib.get("multiplier"):
+                    logger.warning(f"skipping multiplier in unit {units.attrib['name']}")
+                if unit.attrib.get("multiplier"):
+                    logger.warning(f"skipping multiplier in unit {units.attrib['name']}")
+                cellml_unit = unit.attrib.get("units")
+
+                prefix = prefix_map[unit.attrib.get("prefix")]
+                exponent = unit.attrib.get("exponent", "1")
+                if cellml_unit in si_unit_map:
+                    abbrev = si_unit_map[cellml_unit]
+                    name = prefix + abbrev
+                    if exponent not in ["0", "1"]:
+                        fullname = name + "**" + exponent
+                    else:
+                        fullname = name
+
+                    collected_parts[name] = (fullname, exponent)
+                elif cellml_unit in collected_units:
+                    if prefix:
+                        logger.warning(f"Skipping prefix of unit '{cellml_unit}'")
+                    for name, (fullnam, part_exponent) in list(
+                        collected_units[cellml_unit].items(),
+                    ):
+                        new_exponent = float(part_exponent) * float(exponent)
+
+                        if new_exponent % 1.0 == 0.0:
+                            new_exponent = str(int(new_exponent))
+                        else:
+                            new_exponent = str(new_exponent)
+
+                        if new_exponent not in ["0", "1"]:
+                            fullname = name + "**" + new_exponent
+                        else:
+                            fullname = name
+
+                        collected_parts[name] = (fullname, exponent)
+
+                elif units not in parsed_twice:
+                    all_units.append(units)
+                    parsed_twice.append(units)
+                    break
+                else:
+                    logger.warning(
+                        "Unknown unit '{0}' in {1}".format(cellml_unit, units["name"]),
+                    )
+
+            else:
+                # Try change mole*l**-1 to mM...
+
+                collected_units[unit_name] = collected_parts
+                unit_map[unit_name] = "*".join(
+                    fullname for fullname, exp in list(collected_parts.values())
+                )
+
+        # Store unit map
+        self.units_map = unit_map
+
+    def get_iterator(self, name, item=None):
+        """
+        Return an element tree iterator
+        """
+
+        item = item if item is not None else self.cellml
+        return item.iter(self.cellml_namespace + name)
+
+    def check_and_register_component_variables(
+        self,
+        comp,
+        collected_states,
+        collected_parameters,
+        collected_equations,
+    ):
+        """
+        Check if component variables are allready collected
+        """
+
+        # Check for duplication of states
+        for name in list(comp.state_variables.keys()):
+            der_name = f"d{name}_dt"
+            if name in self._params["change_state_names"]:
+                newname = name + "_" + comp.name.split("_")[0]
+                comp.change_state_name(name, newname)
+                name = newname
+
+            # Check state name vs collected state names
+            elif name in collected_states:
+                state_comp = collected_states[name]
+                logger.info(
+                    "Same state name: '{0}' is used in component: '{1}' " "and '{2}'.".format(
+                        name, comp.name, state_comp.name
+                    ),
+                )
+                for change_comp in [comp, state_comp]:
+                    if (
+                        change_comp.state_variables[name]["private"]
+                        and change_comp.variable_info[der_name]["private"]
+                    ):
+                        new_name = change_comp.change_state_name(name)
+                        if change_comp == state_comp:
+                            collected_states[new_name] = change_comp
+                        break
+                else:
+                    logger.warning(
+                        "Could not resolve duplicated state name {0} in "
+                        "component {1} and {2}. None of them are private "
+                        "to the components.".format(name, comp.name, state_comp.name),
+                    )
+
+            # Check state name vs collected parameter names
+            elif name in collected_parameters:
+                param_comp = collected_parameters[name]
+                logger.info(
+                    "State name: '{0}' from component '{1}' is used as "
+                    "parameter in component '{2}'.".format(
+                        name,
+                        comp.name,
+                        param_comp.name,
+                    ),
+                )
+
+                # If parameter is private we change that
+                if param_comp.parameters[name]["private"]:
+                    new_name = param_comp.change_parameter_name(name)
+                    collected_parameters.pop(name)
+                    collected_parameters[new_name] = param_comp
+
+                # Elseif the state variable is private we change that one
+                elif (
+                    comp.state_variables[name]["private"]
+                    and comp.variable_info[der_name]["private"]
+                ):
+                    name = comp.change_state_name(name)
+
+                else:
+                    logger.warning(
+                        "Could not resolve duplicated state and "
+                        "parameter name {0} in component {1} and {2}. "
+                        "None of them are private to the "
+                        "components.".format(name, comp.name, param_comp.name),
+                    )
+
+            # Check state name vs collected equation names
+            elif name in collected_equations:
+                eq_comp = collected_equations[name]
+                logger.info(
+                    "State name '{0}' from component '{1}' is used as "
+                    "parameter in component '{2}'.".format(
+                        name,
+                        comp.name,
+                        eq_comp.name,
+                    ),
+                )
+
+                # If state is private we change it
+                if (
+                    comp.state_variables[name]["private"]
+                    and comp.variable_info[der_name]["private"]
+                ):
+                    name = comp.change_state_name(name)
+                elif eq_comp.variable_info[name]["private"]:
+                    new_name = eq_comp.change_equation_name(name)
+                    collected_equations.pop(name)
+                    collected_equations[new_name] = eq_comp
+
+                else:
+                    logger.warning(
+                        "Could not resolve duplicated state and "
+                        "equation name {0} in component {1} and {2}. "
+                        "None of them are private to the "
+                        "components.".format(name, comp.name, eq_comp.name),
+                    )
+
+            # Register the collected state
+            collected_states[name] = comp
+
+        # Check parameters
+        for name in list(comp.parameters.keys()):
+            # Check parameter name vs collected state names
+            if name in collected_states:
+                state_comp = collected_states[name]
+                der_name = f"d{name}_dt"
+                logger.info(
+                    "Same parameter and state name: '{0}' is used in "
+                    "component '{1}' and '{2}'.".format(
+                        name,
+                        comp.name,
+                        state_comp.name,
+                    ),
+                )
+                # If parameter is private we change that
+                if comp.parameters[name]["private"]:
+                    name = comp.change_parameter_name(name)
+                elif (
+                    state_comp.state_variables[name]["private"]
+                    and state_comp.variable_info[der_name]["private"]
+                ):
+                    new_name = state_comp.change_state_name(name)
+                    collected_states.pop(name)
+                    collected_states[new_name] = state_comp
+
+                else:
+                    logger.warning(
+                        "Could not resolve duplicated state name {0} in "
+                        "component {1} and {2}. None of them are private "
+                        "to the components.".format(name, comp.name, state_comp.name),
+                    )
+
+            # Check state name vs collected parameter names
+            elif name in collected_parameters:
+                param_comp = collected_parameters[name]
+                logger.info(
+                    "Parameter name '{0}' from component '{1}' is used as "
+                    "parameter in component '{2}'.".format(
+                        name,
+                        comp.name,
+                        param_comp.name,
+                    ),
+                )
+
+                # If registered parameter is private we change that
+                if param_comp.parameters[name]["private"]:
+                    new_name = param_comp.change_parameter_name(name)
+                    collected_parameters.pop(name)
+                    collected_parameters[new_name] = param_comp
+
+                # if the parameter is private we change that one
+                elif comp.parameters[name]["private"]:
+                    name = comp.change_parameter_name(name)
+
+                else:
+                    logger.warning(
+                        "Could not resolve duplicated parameter names "
+                        "{0} in component {1} and {2}. "
+                        "None of them are private to the "
+                        "components.".format(name, comp.name, param_comp.name),
+                    )
+
+            # Check state name vs collected equation names
+            elif name in collected_equations:
+                eq_comp = collected_equations[name]
+                logger.info(
+                    "Parameter name '{0}' from component '{1}' "
+                    "is used as parameter in component '{2}'.".format(
+                        name,
+                        comp.name,
+                        eq_comp.name,
+                    ),
+                )
+
+                # If parameter is private we change it
+                if comp.parameters[name]["private"]:
+                    name = comp.change_parameter_name(name)
+                elif eq_comp.variable_info[name]["private"]:
+                    new_name = eq_comp.change_equation_name(name)
+                    collected_equations.pop(name)
+                    collected_equations[new_name] = eq_comp
+
+                else:
+                    logger.warning(
+                        "Could not resolve duplicated parameter and "
+                        "equation names {0} in component {1} and {2}. "
+                        "None of them are private to the "
+                        "components.".format(name, comp.name, eq_comp.name),
+                    )
+            collected_parameters[name] = comp
+
+        # Check equation name
+        for eq in comp.equations:
+            name = eq.name
+
+            # If the equation is private we do not care if it is duplicated
+            # elsewhere. Risky...
+            # if comp.variable_info[name]["private"]:
+            #    collected_equations[name] = comp
+            #    continue
+
+            # If the equation will be broadcasted to another name we continue
+            # print comp.name, name, self.new_variable_connections.get(comp.name, {}).keys()
+            # if name in self.new_variable_connections.get(comp.name, {}).keys():
+            #    continue
+
+            # Check equation name vs collected state names
+            if name in collected_states:
+                state_comp = collected_states[name]
+                der_name = f"d{name}_dt"
+                logger.info(
+                    "Same equation and state name '{0}' is used in "
+                    "component '{1}' and '{2}'.".format(
+                        name,
+                        comp.name,
+                        state_comp.name,
+                    ),
+                )
+                # If equation is private we change that
+                # if comp.variable_info[name]["private"]:
+                #    name = comp.change_equation_name(name)
+                if (
+                    state_comp.state_variables[name]["private"]
+                    and state_comp.variable_info[der_name]["private"]
+                ):
+                    new_name = state_comp.change_state_name(name)
+                    collected_states.pop(name)
+                    collected_states[new_name] = state_comp
+
+                else:
+                    logger.warning(
+                        "Could not resolve duplicated state and "
+                        "equation name {0} in component {1} and {2}. "
+                        "None of them are private to the "
+                        "components.".format(name, comp.name, state_comp.name),
+                    )
+
+            # Check equation name vs collected parameter names
+            elif name in collected_parameters:
+                param_comp = collected_parameters[name]
+                logger.info(
+                    "Equation name '{0}' from component '{1}' is used as "
+                    "parameter in component '{2}'.".format(
+                        name,
+                        comp.name,
+                        param_comp.name,
+                    ),
+                )
+
+                # If registered parameter is private we change that
+                if param_comp.parameters[name]["private"]:
+                    new_name = param_comp.change_parameter_name(name)
+                    collected_parameters.pop(name)
+                    collected_parameters[new_name] = param_comp
+
+                # If the parameter is private we change that one
+                # elif comp.variable_info[name]["private"]:
+                #    name = comp.change_equation_name(name)
+
+                else:
+                    logger.warning(
+                        "Could not resolve duplicated parameter and "
+                        "equation name {0} in component {1} and {2}. "
+                        "None of them are private to the "
+                        "components.".format(name, comp.name, param_comp.name),
+                    )
+
+            # Check equation name vs collected equation names
+            elif name in collected_equations:
+                eq_comp = collected_equations[name]
+                logger.info(
+                    "Equation name '{0}' from component '{1}' is used as "
+                    "equation name in component '{2}'.".format(
+                        name,
+                        comp.name,
+                        eq_comp.name,
+                    ),
+                )
+
+                # If equation is private we change it
+                # if comp.variable_info[name]["private"] and \
+                #       eq_comp.variable_info[name]["private"]:
+                #    warning("Both equations are private. We do not change "\
+                #            "name on either one of them.")
+
+                # elif eq_comp.variable_info[name]["private"]:
+                #    new_name = eq_comp.change_equation_name(name)
+                #    collected_equations.pop(name)
+                #    collected_equations[new_name] = eq_comp
+                #
+                # else:
+                #    warning("Could not resolve duplicated parameter and "\
+                #            "equation names {0} in component {1} and {2}. "\
+                #            "None of them are private to the "\
+                #            "components.".format(name, comp.name, eq_comp.name))
+
+            collected_equations[name] = comp
+
+    def parse_imported_model(self):
+        """
+        Parse any imported models
+        """
+
+        components = OrderedDict()
+
+        # Collect states and parameters to check for duplicates
+        collected_states = dict()
+        collected_parameters = dict()
+        collected_equations = dict()
+
+        # Import other models
+        imports = self.get_iterator("import")
+        if imports:
+            logger.info("Parsing imported models:")
+        for model in imports:
+            import_comp_names = dict()
+
+            for comp in self.get_iterator("component", model):
+                import_comp_names[comp.attrib["component_ref"]] = comp.attrib["name"]
+
+            model_parser = CellMLParser(
+                model.attrib["{http://www.w3.org/1999/xlink}href"],
+                targets=import_comp_names,
+            )
+
+            for comp in model_parser.components:
+                components[comp.name] = comp
+
+        # Extract states, parameters and equations
+        for comp in list(components.values()):
+            self.check_and_register_component_variables(
+                comp,
+                collected_states,
+                collected_parameters,
+                collected_equations,
+            )
+
+        return components, collected_states, collected_parameters, collected_equations
+
+    def get_parents(self, grouping, element=None):
+        """
+        If group was used in the cellml use it to gather parent information
+        about the components
+        """
+
+        # Collect component encapsulation
+        def get_encapsulation(elements, all_parents, parent=None):
+            children = {}
+            for encap in elements:
+                name = encap.attrib["component"]
+                all_parents[name] = parent
+                if list(encap):
+                    nested_children = get_encapsulation(list(encap), all_parents, name)
+                    children[name] = dict(children=nested_children, parent=parent)
+                else:
+                    children[name] = dict(children=None, parent=parent)
+
+            return children
+
+        encapsulations = dict()
+        all_parents = dict()
+        for group in self.get_iterator("group", element):
+            children = list(group)
+
+            if children and children[0].attrib.get("relationship") == grouping:
+                encapsulations = get_encapsulation(children[1:], all_parents)
+
+        # If no group information in cellml extract potential parent information
+        # from component names
+        if not all_parents:
+            # Iterate over the components
+            comp_names = [comp.attrib["name"] for comp in self.get_iterator("component", element)]
+
+            for parent_name in comp_names:
+                for name in comp_names:
+                    if parent_name in name and parent_name != name:
+                        all_parents[name] = parent_name
+
+        return encapsulations, all_parents
+
+    def parse_single_component(
+        self,
+        comp,
+        collected_states,
+        collected_parameters,
+        collected_equations,
+    ):
+        """
+        Parse a single component and create a Component object
+        """
+        comp_name = comp.attrib["name"]
+
+        # Collect variables and equations
+        variables = OrderedDict()
+        equations = []
+        state_variables = OrderedDict()
+        # derivatives = []
+
+        # Get variables that are used outside the component
+        variables_used_in_connections = list(
+            self.new_variable_connections.get(comp_name, dict()).keys(),
+        ) + list(self.same_variable_connections.get(comp_name, dict()).keys())
+
+        # Get variable and initial values
+        for var in self.get_iterator("variable", comp):
+            var_name = var.attrib["name"]
+            if var_name in _all_keywords:
+                var_name = var_name + "_"
+
+            # Check connection and pair it with interface information to
+            # check if a variable is public or not
+            public = var_name in variables_used_in_connections and (
+                var.attrib.get("public_interface") == "out"
+                or var.attrib.get("private_interface") == "out"
+            )
+
+            # Store variables using initial and unit
+            variables[var_name] = dict(
+                init=var.attrib.get("initial_value"),
+                unit=self.units_map[var.attrib.get("units")],
+                private=not public,
+                public_interface=var.attrib.get("public_interface"),
+                private_interface=var.attrib.get("private_interface"),
+            )
+
+        # Get equations
+        for math in comp.iter("{http://www.w3.org/1998/Math/MathML}math"):
+            for eq in list(math):
+                (
+                    equation_list,
+                    state_variable,
+                    derivative,
+                    used_variables,
+                ) = self.mathmlparser.parse(eq)
+
+                # Get equation name
+                eq_name = equation_list[0]
+
+                if eq_name in _all_keywords:
+                    equation_list[0] = eq_name + "_"
+                    eq_name = equation_list[0]
+
+                # Discard collected equation name from used variables
+                used_variables.discard(eq_name)
+
+                assert re.findall(r"(\w+)", eq_name)[0] == eq_name
+                assert equation_list[1] == self.mathmlparser["eq"]
+                equations.append(Equation(eq_name, equation_list[2:], used_variables))
+
+                # Do not register state variables twice
+                if state_variable is not None and state_variable not in state_variables:
+                    state_variables[state_variable] = derivative
+
+        # Create Component
+        comp = Component(comp_name, variables, equations, state_variables)
+
+        # Collect and check variables
+        self.check_and_register_component_variables(
+            comp,
+            collected_states,
+            collected_parameters,
+            collected_equations,
+        )
+
+        return comp
+
+    def sort_components(self, components, sorted_once=False):
+        if not sorted_once:
+            logger.info("Sorting components with respect to dependencies")
+        else:
+            logger.info("Sorting components with respect to dependencies second time")
+
+        # Check internal dependencies
+        for comp0 in components:
+            for comp1 in components:
+                if comp0 == comp1:
+                    continue
+                comp0.check_dependencies(comp1)
+
+        def simple_sort(components):
+            components = deque(components)
+            dependant_components = []
+            sorted_components = []
+            while components:
+                component = components.popleft()
+
+                # Chek for circular dependancy
+                if dependant_components.count(component) > 4:
+                    components.append(component)
+                    break
+
+                if any(dep in components for dep in component.dependencies):
+                    components.append(component)
+                    dependant_components.append(component)
+                else:
+                    sorted_components.append(component)
+
+            return sorted_components, list(components)
+
+        # Initial sorting
+        sorted_components, circular_components = simple_sort(components)
+
+        # If no circular dependencies
+        if not circular_components:
+            return sorted_components
+
+        try:
+            import networkx as nx
+        except ImportError:
+            logger.warning(
+                "networkx could not be imported. Circular "
+                "dependencies between components will not be sorted out.",
+            )
+            return sorted_components + circular_components
+
+        # Collect zero and one dependencies
+        zero_dep_equations = set()
+        one_dep_equations = set()
+        equation_map = {}
+
+        # Gather zero dependent equations
+        for comp in circular_components:
+            for dep_comp, equations in list(comp.dependencies.items()):
+                for equation in equations:
+                    if not equation.dependent_equations and equation.name in comp.used_variables:
+                        zero_dep_equations.add(equation)
+                        equation_map[equation.name] = equation
+
+        # Check for one dependency if that is the zero one
+        one_dep_zero_dep = defaultdict(set)
+        for comp in circular_components:
+            for dep_comp, equations in list(comp.dependencies.items()):
+                for equation in equations:
+                    if (
+                        len(equation.dependent_equations) == 1
+                        and equation.name in comp.used_variables
+                        and equation.dependent_equations[0] in zero_dep_equations
+                    ):
+                        equation_map[equation.name] = equation
+                        one_dep_equations.add(equation)
+                        one_dep_zero_dep[equation.name].add(
+                            equation.dependent_equations[0].name,
+                        )
+
+        # Try to eliminate circular dependency
+        # Extract dependent equation to a new component
+
+        # Find ODE component. If not found create one
+        for comp in components:
+            if comp.name == self.name:
+                ode_comp = comp
+                break
+        else:
+            ode_comp = Component(self.name, {}, [], {})
+
+        # Valid edges for removal
+        valid_edges = [eq.name for eq in zero_dep_equations] + [eq.name for eq in one_dep_equations]
+
+        G = nx.MultiDiGraph()
+        G.add_nodes_from([comp.name for comp in components])
+
+        # Build graph
+        for comp in components:
+            [
+                G.add_edge(dep.name, comp.name, key=equation.name)
+                for dep, equations in list(comp.dependencies.items())
+                for equation in equations
+            ]
+
+        # collecte edges that breaks cycles
+        cycle_breakers = []
+
+        # Collect data over the best edge to remove
+        edge_score = defaultdict(lambda: 0)
+        edge_to_nodes = defaultdict(set)
+        for cycle in nx.simple_cycles(G):
+            local_breaker = []
+            for n0, n1 in zip(cycle[:-1], cycle[1:]):
+                if all(edge in valid_edges for edge in G[n0][n1]):
+                    local_breaker.append([edge for edge in G[n0][n1]])
+                    for edge in local_breaker[-1]:
+                        edge_to_nodes[edge].add((n0, n1))
+            cycle_breakers.append(local_breaker)
+            for local_edges in local_breaker:
+                for edge in local_edges:
+                    edge_score[edge] += 1
+
+        # Sort the edges we should remove by a score given by how many
+        # cycles it breaks by being removed.
+        edge_score = sorted((edge_score[edge], edge) for edge in edge_score)
+
+        # Collect edges to be removed
+        edge_removal = set()
+        cycles_fixed = [False] * len(cycle_breakers)
+
+        while not all(cycles_fixed) and edge_score:
+            score, edge = edge_score.pop()
+
+            # Remove this/these edge/edges this iteration
+            local_removal = [edge]
+
+            # If adding a one dep edge we need to also remove its dependent edge
+            dep_removal = set()
+            if edge in one_dep_zero_dep:
+                local_removal.extend(one_dep_zero_dep[edge])
+                dep_removal.update(one_dep_zero_dep[edge])
+
+            for edge_remove in local_removal:
+                # Iterate over the different cycles
+                for i, local_breakers in enumerate(cycle_breakers):
+                    # If the cycle is fixed
+                    if cycles_fixed[i]:
+                        continue
+
+                    # Go through the collected valid breakers and pick the one
+                    # with least edges first
+                    for j, local_edges in enumerate(
+                        sorted(
+                            local_breakers,
+                            key=cmp_to_key(lambda o0, o1: cmp(len(o0), len(o1))),
+                        ),
+                    ):
+                        # If the removed edge is in the local edges
+                        if edge_remove in local_edges:
+                            local_edges.remove(edge_remove)
+                            edge_removal.add(edge_remove)
+
+                            # Check any dependent edges
+                            for dep_edge in one_dep_zero_dep.get(edge_remove, []):
+                                edge_removal.add(dep_edge)
+
+                            if len(local_edges) == 0:
+                                cycles_fixed[i] = True
+
+                                break
+
+        # If no edge sugested for removal we pick the zero dep equations
+        if not edge_removal:
+            if zero_dep_equations:
+                edge_removal = [eq.name for eq in zero_dep_equations]
+            elif one_dep_equations:
+                edge_removal = [eq.name for eq in one_dep_equations]
+            else:
+                logger.warning("Could not sort out circular dependencies.")
+
+        # Remove the edges from the graph
+        for edge in edge_removal:
+            for n0, n1 in edge_to_nodes[edge]:
+                G.remove_edge(n0, n1, key=edge)
+
+        # Move the marked edges (equations) from the relevant components
+        removed_equations = {}
+        for edge in edge_removal:
+            eq = equation_map[edge]
+
+            old_comp = eq.component
+            ode_comp.equations.append(eq)
+            old_comp.equations.remove(eq)
+            ode_comp.variable_info[eq.name] = old_comp.variable_info.pop(eq.name)
+
+            # Store changed
+            removed_equations[eq] = old_comp
+
+            # Transfer used_in to new component
+            new_dependent_componets = OrderedDict()
+            for dep_comp, equations in list(old_comp.used_in.items()):
+                assert equations
+
+                if eq not in equations or dep_comp == ode_comp:
+                    continue
+
+                # Remove dependency from old component and add it to the new
+                if len(equations) == 1:
+                    new_dependent_componets[dep_comp] = old_comp.used_in.pop(dep_comp)
+                else:
+                    new_dependent_componets[dep_comp] = [
+                        old_comp.used_in[dep_comp].pop(equations.index(eq)),
+                    ]
+
+                # Change component dependencies
+                if old_comp in dep_comp.dependencies and eq in dep_comp.dependencies[old_comp]:
+                    if len(dep_comp.dependencies[old_comp]) == 1:
+                        dep_comp.dependencies.pop(old_comp)
+                    else:
+                        dep_comp.dependencies[old_comp].remove(eq)
+
+                if ode_comp not in dep_comp.dependencies:
+                    dep_comp.dependencies[ode_comp] = [eq]
+                else:
+                    dep_comp.dependencies[ode_comp].append(eq)
+
+            # Store new component to the extracted equation
+            eq.component = ode_comp
+            ode_comp.dependent_componets = new_dependent_componets
+
+            if ode_comp not in sorted_components:
+                sorted_components.insert(0, ode_comp)
+
+        # Sort newly added equations
+        ode_comp.sort_and_store_equations(ode_comp.equations)
+
+        # Sort graph components and apply the sortings to the collected
+        # CellML compoents
+        sort_again = False
+        try:
+            sorted_components = list(nx.topological_sort(G))
+            components.sort(key=lambda n0: sorted_components.index(n0.name))
+            message = "To avoid circular dependency the following equations " "has been moved:"
+
+        except nx.NetworkXUnfeasible as e:
+            logger.warning("Topological sort failed: " + str(e))
+            message = (
+                "In a try to avoid circular dependency the following equations " "has been moved:"
+            )
+            sort_again = True
+
+        # Insert the ODE component with extracted equations first
+        components.insert(0, ode_comp)
+
+        logger.warning(message)
+
+        for eq, old_comp in list(removed_equations.items()):
+            logger.warning(f"{eq.name} : from {old_comp.name} to {ode_comp.name} component")
+
+        if sort_again:
+            # Try rebuild the graph and make another topological sort
+            G = nx.MultiDiGraph()
+            G.add_nodes_from([comp.name for comp in components])
+
+            # Build graph
+            for comp in components:
+                [
+                    G.add_edge(dep.name, comp.name, key=equation.name)
+                    for dep, equations in list(comp.dependencies.items())
+                    for equation in equations
+                ]
+
+            try:
+                sorted_components = list(nx.topological_sort(G))
+                components.sort(key=lambda n0: sorted_components.index(n0.name))
+            except nx.NetworkXUnfeasible as e:
+                logger.warning("Topological sort failed a second time: " + str(e))
+
+        return components
+
+    def parse_components(self, targets):
+        """
+        Build a dictionary containing dictionarys describing each
+        component of the cellml model
+        """
+
+        # First parse connections which is used to determine the interface of
+        # each variable
+        (
+            self.new_variable_connections,
+            self.same_variable_connections,
+        ) = self.parse_connections()
+
+        # Parse imported components
+        (
+            components,
+            collected_states,
+            collected_parameters,
+            collected_equations,
+        ) = self.parse_imported_model()
+
+        # Get parent relationship between components
+        encapsulations, all_parents = self.get_parents(self._params["grouping"])
+
+        if targets:
+            # If the parent information was not of type encapsulation
+            # regather parent information
+            if self._params["grouping"] != "encapsulation":
+                encapsulations, dummy = self.get_parents("encapsulation")
+
+            # Add any encapsulated components to the target list
+            for target, new_target_name in list(targets.items()):
+                if target in encapsulations:
+                    for child in encapsulations[target]["children"]:
+                        targets[child] = child.replace(target, new_target_name)
+
+            target_parents = dict()
+
+            # Update all_parents
+            for comp_name, parent_name in list(all_parents.items()):
+                if parent_name not in targets:
+                    continue
+                target_parents[targets[comp_name]] = targets[parent_name]
+
+        # Iterate over the components
+        for comp in self.get_iterator("component"):
+            comp_name = comp.attrib["name"]
+
+            # Only parse selected and non-empty components
+            if (targets and comp_name not in targets) or len(list(comp)) == 0:
+                continue
+
+            # If targets provides a name mapping give the component a new name
+            if targets and isinstance(targets, dict):
+                new_name = targets[comp_name]
+                comp.attrib["name"] = new_name
+                comp_name = new_name
+
+            # Store component
+            components[comp_name] = self.parse_single_component(
+                comp,
+                collected_states,
+                collected_parameters,
+                collected_equations,
+            )
+
+        # Add parent information
+        all_component_names = list(components.keys())
+        for name, comp in list(components.items()):
+            if targets:
+                parent_name = target_parents.get(name)
+            else:
+                parent_name = all_parents.get(name)
+
+            if parent_name:
+                comp.parent = components[parent_name]
+
+                # If parent name in child name, reduce child name length
+                if self._params["strip_parent_name"] and parent_name in comp.name:
+                    old_name = comp.name
+                    new_name = old_name.replace(parent_name, "").strip("_")
+                    if new_name not in all_component_names:
+                        comp.name = new_name
+                        all_component_names.remove(old_name)
+                        all_component_names.append(new_name)
+
+                components[parent_name].children.append(comp)
+
+        # If we only extract a sub set of component we do not sort
+        if targets:
+            return list(components.values())
+
+        # Before dependencies are checked we change names according to
+        # variable mappings in the original CellML file
+        if self.new_variable_connections:
+            logger.info("\nRenaming variables through connections")
+
+        for comp, variables in list(self.new_variable_connections.items()):
+            # Iterate over old and new names
+            for oldname, newnames in list(variables.items()):
+                # Check that the direction of the connection is correct
+                # If no variable info is registered for this comp or its
+                # children it is the wrong direction
+
+                # print
+                # print comp, oldname
+                # print components[comp].variable_info.keys()
+                # for child in components[comp].children:
+                #    print child.name, child.variable_info.keys()
+                #    if oldname in child.variable_info.keys():
+                #        print "HURRAY"
+                #        print child.variable_info[oldname]
+
+                if oldname not in components[comp].variable_info and all(
+                    oldname not in child.variable_info for child in components[comp].children
+                ):
+                    continue
+
+                # Try access var_info
+                var_info = components[comp].variable_info.get(oldname)
+
+                # If not we try components children
+                if var_info is None:
+                    for child in components[comp].children:
+                        if oldname in child.variable_info:
+                            var_info = child.variable_info[oldname]
+                            break
+
+                # If variable is not intended out
+                if not (
+                    var_info.get("public_interface") == "out"
+                    or var_info.get("private_interface") == "out"
+                ):
+                    continue
+
+                # Check if the oldname is used in any components
+                old_name_used = self.same_variable_connections[comp].get(oldname)
+
+                # If there are only one newname we change the name of the
+                # original equation
+                if len(newnames) == 1:
+                    # If not old name used or old name only used in children and
+                    # we then assume it is private to the component relationship
+                    # parent-child
+                    if not old_name_used or all(
+                        components[other_comp] in components[comp].children
+                        for other_comp in old_name_used
+                    ):
+                        # Get new name
+                        newname = list(newnames.keys())[0]
+
+                        # If oldname in component
+                        if components[comp].variable_info.get(oldname) is not None:
+                            components[comp].change_variable_name(oldname, newname)
+
+                        if old_name_used:
+                            for other_comp in old_name_used:
+                                components[other_comp].change_variable_name(
+                                    oldname,
+                                    newname,
+                                )
+
+                        for child in components[comp].children:
+                            if child.variable_info.get(oldname) is not None:
+                                child.change_variable_name(oldname, newname)
+                    else:
+                        # FIXME: Add equation with name change to component
+                        pass
+                else:
+                    # FIXME: Add equation with name change to component
+                    pass
+
+        # Add dependencies and sort the components accordingly
+        return self.sort_components(list(components.values()))
+
+    def parse_connections(self):
+        new_variable_names = dict()
+        same_variable_names = dict()
+
+        for con in self.get_iterator("connection"):
+            con_map = list(self.get_iterator("map_components", con))[0]
+            comp1 = con_map.attrib["component_1"]
+            comp2 = con_map.attrib["component_2"]
+
+            for var_map in self.get_iterator("map_variables", con):
+                var1 = var_map.attrib["variable_1"]
+                var2 = var_map.attrib["variable_2"]
+
+                if var1 != var2:
+                    if comp1 not in new_variable_names:
+                        new_variable_names[comp1] = {var1: defaultdict(list)}
+                    elif var1 not in new_variable_names[comp1]:
+                        new_variable_names[comp1][var1] = defaultdict(list)
+                    new_variable_names[comp1][var1][var2].append(comp2)
+
+                    # Register both directions
+                    if comp2 not in new_variable_names:
+                        new_variable_names[comp2] = {var2: defaultdict(list)}
+                    elif var2 not in new_variable_names[comp2]:
+                        new_variable_names[comp2][var2] = defaultdict(list)
+                    new_variable_names[comp2][var2][var1].append(comp1)
+
+                else:
+                    if comp1 not in same_variable_names:
+                        same_variable_names[comp1] = {var1: [comp2]}
+                    elif var1 not in same_variable_names[comp1]:
+                        same_variable_names[comp1][var1] = [comp2]
+                    else:
+                        same_variable_names[comp1][var1].append(comp2)
+
+                    # Register both directions
+                    if comp2 not in same_variable_names:
+                        same_variable_names[comp2] = {var2: [comp1]}
+                    elif var2 not in same_variable_names[comp2]:
+                        same_variable_names[comp2][var2] = [comp1]
+                    else:
+                        same_variable_names[comp2][var2].append(comp1)
+
+        return new_variable_names, same_variable_names
+
+    def to_gotran(self):
+        """
+        Generate a gotran file
+        """
+        gotran_lines = []
+        for docline in self.documentation.split("\n"):
+            gotran_lines.append("# " + docline)
+
+        if gotran_lines:
+            gotran_lines.extend([""])
+
+        # Add component info
+        declaration_lines = []
+        equation_lines = []
+
+        def unders_score_replace(comp):
+            new_name = comp.name.replace("_", " ")
+
+            # If only 1 state it might be included in the name
+            state_name = ""
+            if len(comp.state_variables) == 1:
+                state_name = list(comp.state_variables.keys())[0]
+                if state_name in comp.name:
+                    new_name = state_name.join(
+                        part.replace("_", " ") for part in comp.name.split(state_name)
+                    )
+
+            # Captitalize first word
+            single_words = new_name.split(" ")
+            if len(single_words[0]) > 1 and "_" not in single_words[0]:
+                single_words[0] = single_words[0][0].upper() + single_words[0][1:]
+
+            # If first word is only a character we assume the first two
+            # words to stick together
+            elif (
+                len(single_words[0]) == 1
+                and len(single_words) > 1
+                and single_words[0] != state_name
+            ):
+                single_words = [single_words[0] + "_" + single_words[1]] + single_words[2:]
+
+            return " ".join(single_words)
+
+        # Iterate over components and collect stuff
+        for comp in self.components:
+            names = deque([unders_score_replace(comp)])
+
+            parent = comp.parent
+            while parent is not None:
+                names.appendleft(unders_score_replace(parent))
+                parent = parent.parent
+
+            comp_name = ", ".join(f'"{name}"' for name in names)
+
+            # Collect initial state values
+            if comp.state_variables:
+                declaration_lines.append("")
+                declaration_lines.append(f"states({comp_name},")
+                for name, _info in list(comp.state_variables.items()):
+                    if _info["unit"] != "1":
+                        declaration_lines.append(
+                            "       {0} = ScalarParam({1}" ', unit="{2}"),'.format(
+                                name,
+                                float(_info["init"]),
+                                _info["unit"],
+                            ),
+                        )
+                    else:
+                        declaration_lines.append(f"       {name} = {_info['init']},")
+                declaration_lines[-1] = declaration_lines[-1][:-1] + ")"
+
+            # Collect initial parameters values
+            if comp.parameters:
+                declaration_lines.append("")
+                declaration_lines.append(f"parameters({comp_name},")
+                for name, _info in list(comp.parameters.items()):
+                    if _info["unit"] != "1":
+                        declaration_lines.append(
+                            "           {0} = ScalarParam({1}" ', unit="{2}"),'.format(
+                                name,
+                                float(_info["init"]),
+                                _info["unit"],
+                            ),
+                        )
+                    else:
+                        declaration_lines.append(
+                            f"           {name} = {_info['init']},",
+                        )
+                declaration_lines[-1] = declaration_lines[-1][:-1] + ")"
+
+            # Collect all intermediate equations
+            if comp.equations:
+                equation_lines.append("")
+                equation_lines.append(f"expressions({comp_name})")
+                """
+                for eq in comp.equations:
+                    expr = []
+                    for eqi in eq.expr:
+                        if eqi.isdigit():
+                            # This converts integers to floats
+                            expr.append(str(float(eqi)))
+                        else:
+                            expr.append(eqi)
+                    eq.expr = expr
+                """
+
+                equation_lines.extend(
+                    "{0} = {1}{2}".format(
+                        eq.name,
+                        "".join(eq.expr),
+                        " # {0}".format(comp.variable_info[eq.name]["unit"])
+                        if comp.variable_info[eq.name]["unit"] != "1"
+                        else "",
+                    )
+                    for eq in comp.equations
+                )
+
+        gotran_lines.append(
+            f"# gotran file generated by cellml2gotran from {self.model_source}",
+        )
+        gotran_lines.extend(declaration_lines)
+        gotran_lines.extend(equation_lines)
+        gotran_lines.append("")
+        gotran_lines.append("")
+
+        # Return joined lines
+        return "\n".join(gotran_lines)

--- a/src/gotranx/cellml/mathml.py
+++ b/src/gotranx/cellml/mathml.py
@@ -27,11 +27,10 @@ _all_keywords: list[str] = []
 
 
 class MathMLBaseParser(object):
-    def __init__(self, use_sympy_integers=False):
+    def __init__(self):
         self._state_variable = None
         self._derivative = None
         self.variables_names = set()
-        self.use_sympy_integers = use_sympy_integers
 
         self._precedence = {
             "piecewise": 0,
@@ -261,16 +260,6 @@ class MathMLBaseParser(object):
         else:
             exponent = ""
         value += exponent
-
-        if self.use_sympy_integers:
-            # Fix possible strangeness with integer division in Python...
-            nums = [1.0, 2.0, 3.0, 4.0, 5.0, 10.0]
-            num_strs = ["one", "two", "three", "four", "five", "ten"]
-
-            if eval(value) in nums:
-                value = dict(t for t in zip(nums, num_strs))[eval(value)]
-        # elif "." not in value and "e" not in value:
-        #    value += ".0"
 
         return [value]
 

--- a/src/gotranx/cellml/mathml.py
+++ b/src/gotranx/cellml/mathml.py
@@ -1,0 +1,350 @@
+# Copyright (C) 2013 Johan Hake
+#
+# This file is part of Gotran.
+#
+# Gotran is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Gotran is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Gotran. If not, see <http://www.gnu.org/licenses/>.
+
+__all__ = ["MathMLBaseParser", "MathMLCPPParser"]
+import sys
+import structlog
+
+logger = structlog.getLogger(__name__)
+
+_all_keywords: list[str] = []
+
+
+class MathMLBaseParser(object):
+    def __init__(self, use_sympy_integers=False):
+        self._state_variable = None
+        self._derivative = None
+        self.variables_names = set()
+        self.use_sympy_integers = use_sympy_integers
+
+        self._precedence = {
+            "piecewise": 0,
+            "power": 0,
+            "rem": 0.5,
+            "divide": 1,
+            "times": 2,
+            "minus": 4,
+            "plus": 5,
+            "lt": 6,
+            "gt": 6,
+            "leq": 6,
+            "geq": 6,
+            "eq": 10,
+            "exp": 10,
+            "ln": 10,
+            "abs": 10,
+            "floor": 10,
+            "log": 10,
+            "root": 10,
+            "tan": 10,
+            "cos": 10,
+            "sin": 10,
+            "tanh": 10,
+            "cosh": 10,
+            "sinh": 10,
+            "arccos": 10,
+            "arcsin": 10,
+            "arctan": 10,
+        }
+
+        self._operators = {
+            "power": "**",
+            "rem": " % ",
+            "divide": "/",
+            "times": "*",
+            "minus": " - ",
+            "plus": " + ",
+            "lt": " < ",
+            "gt": " > ",
+            "leq": " <= ",
+            "geq": " >= ",
+            "eq": " = ",
+            "exp": "exp",
+            "ln": "log",
+            "abs": "abs",
+            "floor": "floor",
+            "log": "log",
+            "root": "sqrt",
+            "tan": "tan",
+            "cos": "cos",
+            "sin": "sin",
+            "tanh": "tanh",
+            "cosh": "cosh",
+            "sinh": "sinh",
+            "arccos": "acos",
+            "arcsin": "asin",
+            "arctan": "atan",
+        }
+
+    def use_parenthesis(self, child, parent, first_operand=True):
+        """
+        Return true if child operation need parenthesis
+        """
+        if parent is None:
+            return False
+
+        parent_prec = self._precedence[parent]
+        if parent == "minus" and not first_operand:
+            parent_prec -= 0.5
+
+        if parent == "divide" and child == "times" and first_operand:
+            return False
+
+        if parent == "minus" and child == "plus" and first_operand:
+            return False
+
+        return parent_prec < self._precedence[child]
+
+    def __getitem__(self, operator):
+        return self._operators[operator]
+
+    def _gettag(self, node):
+        """
+        Splits off the namespace part from name, and returns the rest, the tag
+        """
+        return "".join(node.tag.split("}")[1:])
+
+    def parse(self, root):
+        """
+        Recursively parse a mathML subtree and return an list of tokens
+        together with any state variable and derivative.
+        """
+        self._state_variable = None
+        self._derivative = None
+        self.used_variables = set()
+
+        equation_list = self._parse_subtree(root)
+        return (
+            equation_list,
+            self._state_variable,
+            self._derivative,
+            self.used_variables,
+        )
+
+    def _parse_subtree(self, root, parent=None, first_operand=True):
+        op = self._gettag(root)
+
+        # If the tag i "apply" pick the operator and continue parsing
+        if op == "apply":
+            children = list(root)
+            op = self._gettag(children[0])
+            root = children[1:]
+        # If use special method to parse
+        if hasattr(self, "_parse_" + op):
+            return getattr(self, "_parse_" + op)(root, parent)
+        elif op in list(self._operators.keys()):
+            # Build the equation string
+            eq = []
+
+            # Check if we need parenthesis
+            use_parent = self.use_parenthesis(op, parent, first_operand)
+
+            # If unary operator
+            if len(root) == 1:
+                # Special case if operator is "minus"
+                if op == "minus":
+                    # If an unary minus is infront of a cn or ci we skip
+                    # parenthesize
+                    if self._gettag(root[0]) in ["ci", "cn"]:
+                        use_parent = False
+
+                    # If an unary minus is infront of a plus we always use parenthesize
+                    if self._gettag(root[0]) == "apply" and self._gettag(
+                        list(root[0])[0],
+                    ) in ["plus", "minus"]:
+                        use_parent = True
+
+                    eq += ["-"]
+
+                else:
+                    # Always use paranthesis for unary operators
+                    use_parent = True
+                    eq += [self._operators[op]]
+
+                eq += ["("] * use_parent + self._parse_subtree(root[0], op) + [")"] * use_parent
+                return eq
+            else:
+                # Binary operator
+                eq += ["("] * use_parent + self._parse_subtree(root[0], op)
+                for operand in root[1:]:
+                    eq = (
+                        eq
+                        + [self._operators[op]]
+                        + self._parse_subtree(operand, op, first_operand=False)
+                    )
+                eq = eq + [")"] * use_parent
+
+                return eq
+        else:
+            logger.error("No support for parsing MathML " + op + " operator.")
+
+    def _parse_conditional(self, condition, operands, parent):
+        return (
+            [condition]
+            + ["("]
+            + self._parse_subtree(operands[0], parent)
+            + [", "]
+            + self._parse_subtree(operands[1], parent)
+            + [")"]
+        )
+
+    def _parse_and(self, operands, parent):
+        ret = ["And("]
+        for operand in operands:
+            ret += self._parse_subtree(operand, parent) + [", "]
+        return ret + [")"]
+
+    def _parse_or(self, operands, parent):
+        ret = ["Or("]
+        for operand in operands:
+            ret += self._parse_subtree(operand, parent) + [", "]
+        return ret + [")"]
+
+    def _parse_lt(self, operands, parent):
+        return self._parse_conditional("Lt", operands, "lt")
+
+    def _parse_leq(self, operands, parent):
+        return self._parse_conditional("Le", operands, "leq")
+
+    def _parse_gt(self, operands, parent):
+        return self._parse_conditional("Gt", operands, "gt")
+
+    def _parse_geq(self, operands, parent):
+        return self._parse_conditional("Ge", operands, "geq")
+
+    def _parse_neq(self, operands, parent):
+        return self._parse_conditional("Ne", operands, "neq")
+
+    def _parse_eq(self, operands, parent):
+        # Parsing conditional
+        if parent == "piecewise":
+            return self._parse_conditional("Eq", operands, "eq")
+
+        # Parsing assignment
+        return (
+            self._parse_subtree(operands[0], "eq")
+            + [self["eq"]]
+            + self._parse_subtree(operands[1], "eq")
+        )
+
+    def _parse_pi(self, var, parent):
+        return ["pi"]
+
+    def _parse_ci(self, var, parent):
+        varname = var.text.strip()
+        if varname in _all_keywords:
+            varname = varname + "_"
+        self.used_variables.add(varname)
+        return [varname]
+
+    def _parse_cn(self, var, parent):
+        value = var.text.strip()
+        if "type" in list(var.keys()) and var.get("type") == "e-notation":
+            # Get rid of potential float repr
+            exponent = "e" + str(int(list(var)[0].tail.strip()))
+        else:
+            exponent = ""
+        value += exponent
+
+        if self.use_sympy_integers:
+            # Fix possible strangeness with integer division in Python...
+            nums = [1.0, 2.0, 3.0, 4.0, 5.0, 10.0]
+            num_strs = ["one", "two", "three", "four", "five", "ten"]
+
+            if eval(value) in nums:
+                value = dict(t for t in zip(nums, num_strs))[eval(value)]
+        # elif "." not in value and "e" not in value:
+        #    value += ".0"
+
+        return [value]
+
+    def _parse_diff(self, operands, parent):
+        # Store old used_variables so we can erase any collected state
+        # variables
+        used_variables_prior_parse = self.used_variables.copy()
+
+        x = "".join(self._parse_subtree(operands[1], "diff"))
+        y = "".join(self._parse_subtree(operands[0], "diff"))
+
+        if x in _all_keywords:
+            x = x + "_"
+
+        if y == "time":
+            y = "t"
+
+        d = "d" + x + "_d" + y
+
+        # Restore used_variables
+        self.used_variables = used_variables_prior_parse
+
+        # Store derivative
+        self.used_variables.add(d)
+
+        # This is an in/out variable remember it
+        self._derivative = d
+        self._state_variable = x
+        return [d]
+
+    def _parse_bvar(self, var, parent):
+        if len(var) == 1:
+            return self._parse_subtree(var[0], "bvar")
+        else:
+            logger.error("ERROR: No support for higher order derivatives.")
+
+    def _parse_piecewise(self, cases, parent=None):
+        if len(cases) == 2:
+            piece_children = list(cases[0])
+            cond = self._parse_subtree(piece_children[1], "piecewise")
+            true = self._parse_subtree(piece_children[0])
+            false = self._parse_subtree(list(cases[1])[0])
+            return ["Conditional", "("] + cond + [", "] + true + [", "] + false + [")"]
+        else:
+            piece_children = list(cases[0])
+            cond = self._parse_subtree(piece_children[1], "piecewise")
+            true = self._parse_subtree(piece_children[0])
+            return (
+                ["Conditional", "("]
+                + cond
+                + [", "]
+                + true
+                + [", "]
+                + self._parse_piecewise(cases[1:])
+                + [")"]
+            )
+
+
+class MathMLCPPParser(MathMLBaseParser):
+    def _parse_power(self, operands):
+        return (
+            ["pow", "("]
+            + self._parse_subtree(operands[0])
+            + [", "]
+            + self._parse_subtree(operands[1])
+            + [")"]
+        )
+
+    def _parse_piecewise(self, cases):
+        if len(cases) == 2:
+            piece_children = cases[0].getchildren()
+            cond = self._parse_subtree(piece_children[1])
+            true = self._parse_subtree(piece_children[0])
+            false = self._parse_subtree(cases[1].getchildren()[0])
+            return ["("] + cond + ["?"] + true + [":"] + false + [")"]
+        else:
+            sys.exit(
+                "ERROR: No support for cases with other than two " "possibilities.",
+            )

--- a/src/gotranx/cellml/mathml.py
+++ b/src/gotranx/cellml/mathml.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # Copyright (C) 2013 Johan Hake
 #
 # This file is part of Gotran.

--- a/src/gotranx/cli/__init__.py
+++ b/src/gotranx/cli/__init__.py
@@ -49,6 +49,7 @@ def main(
     ),
     outname: typing.Optional[str] = typer.Option(
         None,
+        "-o",
         "--outname",
         help="Output name",
     ),
@@ -69,7 +70,15 @@ def main(
     scheme: Annotated[typing.Optional[typing.List[Scheme]], typer.Option()] = None,
 ):
     if fname is None:
-        return
+        return typer.echo("No file specified")
+
+    if to == "":
+        # Check if outname is specified
+        if outname is None:
+            return typer.echo("No output name specified")
+        else:
+            to = Path(outname).suffix
+
     if to in {".c", ".h"}:
         from . import gotran2c
 
@@ -78,3 +87,8 @@ def main(
         from . import gotran2py
 
         gotran2py.main(fname=fname, suffix=to, outname=outname, scheme=scheme)
+
+    if to in {".ode"}:
+        from .cellml2ode import main as cellml2ode
+
+        cellml2ode(fname=fname, outname=outname)

--- a/src/gotranx/cli/cellml2ode.py
+++ b/src/gotranx/cli/cellml2ode.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+from pathlib import Path
+from structlog import get_logger
+
+from ..cellml import cellml_to_gotran
+
+logger = get_logger()
+
+
+def main(
+    fname: Path,
+    outname: str | None = None,
+) -> None:
+    assert fname.suffix == ".cellml", f"File {fname} must be a cellml file"
+    assert fname.exists(), f"File {fname} does not exist"
+    logger.info(f"Converting {fname} to gotran ode file")
+    code = cellml_to_gotran(fname)
+    out = fname.with_suffix(".ode") if outname is None else Path(outname)
+    out.write_text(code)
+    logger.info(f"Wrote {out}")

--- a/src/gotranx/load.py
+++ b/src/gotranx/load.py
@@ -4,12 +4,25 @@ from pathlib import Path
 from structlog import get_logger
 
 from . import exceptions
-from .ode import make_ode
+from .ode import make_ode, ODE
 from .parser import Parser
 from .transformer import TreeToODE
 
 
 logger = get_logger()
+
+
+def ode_from_string(text: str, name="ode") -> ODE:
+    parser = Parser(parser="lalr", transformer=TreeToODE())
+    result = parser.parse(text)
+    ode = make_ode(
+        components=result.components,
+        name=name,
+        comments=result.comments,
+    )
+    logger.info(f"Num states {ode.num_states}")
+    logger.info(f"Num parameters {ode.num_parameters}")
+    return ode
 
 
 def load_ode(path: str | Path):
@@ -20,15 +33,4 @@ def load_ode(path: str | Path):
     if not fname.is_file():
         raise exceptions.ODEFileNotFound(fname)
 
-    parser = Parser(parser="lalr", transformer=TreeToODE())
-    with open(fname, "r") as f:
-        result = parser.parse(f.read())
-
-    ode = make_ode(
-        components=result.components,
-        name=fname.stem,
-        comments=result.comments,
-    )
-    logger.info(f"Num states {ode.num_states}")
-    logger.info(f"Num parameters {ode.num_parameters}")
-    return ode
+    return ode_from_string(fname.read_text(), name=fname.stem)

--- a/src/gotranx/ode.lark
+++ b/src/gotranx/ode.lark
@@ -8,11 +8,11 @@
 ?unit: "#" UNIT
 
 comment : ("#" /.+/)+
-parameters : "parameters" "(" [ COMPONENT_NAME "," ] [ INFO ","] parameter ("," parameter)*  ")"
-states : "states" "(" [ COMPONENT_NAME "," ] [ INFO ","] parameter ("," parameter)* ")"
+parameters : "parameters" "("  (COMPONENT_NAME ",")* parameter ("," parameter)*  ")"
+states : "states" "("  (COMPONENT_NAME ",")* parameter ("," parameter)* ")"
 expressions: (assignment)+
-    | "expressions" "(" COMPONENT_NAME [ "," INFO ] ")" (assignment)+
-    | "component" "(" COMPONENT_NAME [ "," INFO ] ")" (assignment)+
+    | "expressions" "(" COMPONENT_NAME ("," COMPONENT_NAME)* ")" (assignment)+
+    | "component" "(" COMPONENT_NAME ("," COMPONENT_NAME)* ")" (assignment)+
 
 
 ?expression: multiplyingexpression

--- a/src/gotranx/ode.py
+++ b/src/gotranx/ode.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from collections import defaultdict
 
 from functools import cached_property
+from pathlib import Path
 from graphlib import TopologicalSorter
 from typing import Iterable
 from typing import Sequence
@@ -291,3 +292,8 @@ class ODE:
 
     def sorted_states(self) -> tuple[atoms.State, ...]:
         return tuple(s.state for s in self.sorted_state_derivatives())
+
+    def save(self, path: Path) -> None:
+        from .save import write_ODE_to_ode_file
+
+        write_ODE_to_ode_file(self, path)

--- a/src/gotranx/save.py
+++ b/src/gotranx/save.py
@@ -2,47 +2,108 @@ from __future__ import annotations
 
 from collections import defaultdict
 from pathlib import Path
-from typing import Iterable
-from typing import TypeVar
+from typing import TypeVar, Callable
+from functools import reduce
 
 from structlog import get_logger
 
 from . import atoms
 from .ode import ODE
+from .codegen.python import PythonCodeGenerator
 
 T = TypeVar("T")
 logger = get_logger()
 
 
-def start_odeblock(case, name=None, info=None):
-    if name is None:
+def break_comment_at_80(acc, x):
+    if len(acc.split("\n")[-1]) + len(x) > 80:
+        return acc + "\n# " + x
+    else:
+        return acc + " " + x
+
+
+class GotranODECodePrinter(PythonCodeGenerator):
+    def print_comments(self) -> str:
+        if len(self.ode.comments) == 0:
+            return ""
+        text = "# "
+
+        for comment in self.ode.comments:
+            text += reduce(break_comment_at_80, comment.text.split(" "))
+
+        text += "\n\n"
+        return text
+
+    def print_states(self) -> str:
+        d: dict[tuple[str, ...], list[atoms.State]] = defaultdict(list)
+        for state in self.ode.states:
+            d[state.components].append(state)
+
+        text = ""
+        for components, states in d.items():
+            text += start_odeblock("states", names=components) + "\n"
+            text += ", ".join([print_ScalarParam(s, doprint=self.printer.doprint) for s in states])
+            text += "\n)\n\n"
+        return text
+
+    def print_parameters(self) -> str:
+        d: dict[tuple[str, ...], list[atoms.Parameter]] = defaultdict(list)
+        for parameter in self.ode.parameters:
+            d[parameter.components].append(parameter)
+
+        text = ""
+        for components, parameters in d.items():
+            text += start_odeblock("parameters", names=components) + "\n"
+            text += ", ".join(
+                [print_ScalarParam(p, doprint=self.printer.doprint) for p in parameters]
+            )
+            text += "\n)\n\n"
+
+        return text
+
+    def print_assignments(self) -> str:
+        d: dict[tuple[str, ...], list[atoms.Assignment]] = defaultdict(list)
+        for i in self.ode.intermediates + self.ode.state_derivatives:
+            d[i.components].append(i)
+
+        text = ""
+        for components, intermediates in d.items():
+            text += start_odeblock("expressions", names=components, is_expression=True) + "\n"
+            text += "\n".join([print_assignment(i) for i in intermediates])
+            text += "\n\n"
+
+        return text
+
+    def format(self, code: str) -> str:
+        return self._formatter(code)
+
+
+def start_odeblock(case: str, names: tuple[str, ...] = (), is_expression: bool = False):
+    if len(names) == 0 or (len(names) == 1 and names[0] == ""):
+        if is_expression:
+            return ""
         return f"{case}("
     else:
-        if info is None:
-            return f'{case}("{name}",'
+        args = ", ".join(f'"{n}"' for n in names)
+
+        if is_expression:
+            return f"{case}({args})"
         else:
-            return f'{case}("{name}", "{info}",'
+            return f"{case}({args},"
 
 
-def print_ScalarParam(p: atoms.Atom) -> str:
+def print_ScalarParam(p: atoms.Atom, doprint: Callable[[str], str]) -> str:
     unit_str = "" if p.unit_str is None else f'unit="{p.unit_str}"'
     description = "" if p.description is None else f'description="{p.description}"'
 
     if unit_str == "" and description == "":
-        ret = f"{p.name}={p.value}"
+        ret = f"{p.name}={doprint(p.value)}"  # type: ignore
     else:
         kwargs_str = ", ".join([unit_str, description])
-        ret = f"{p.name}=ScalarParam({p.value}{kwargs_str})"
+        ret = f"{p.name}=ScalarParam({doprint(p.value)}{kwargs_str})"  # type: ignore
 
     logger.debug(f"Saving parameters {p} as {ret!r}")
     return ret
-
-
-def groupby_attribute(d: Iterable[T], attr: str) -> dict[str, list[T]]:
-    data = defaultdict(list)
-    for di in d:
-        data[getattr(di, attr)].append(di)
-    return dict(data)
 
 
 def print_assignment(a: atoms.Assignment) -> str:
@@ -54,26 +115,11 @@ def print_assignment(a: atoms.Assignment) -> str:
 
 def write_ODE_to_ode_file(ode: ODE, path: Path) -> None:
     # Just make sure it is a Path object
+    printer = GotranODECodePrinter(ode)
     path = Path(path)
     text = ""
-    for component in ode.components:
-        name = component.name
-        logger.debug(f"Saving component {name}")
-
-        for info, parameters in groupby_attribute(component.parameters, "info").items():
-            text += start_odeblock("parameters", name=name, info=info) + "\n"
-            text += ", ".join([print_ScalarParam(p) for p in parameters])
-            text += "\n)\n"
-
-        # FIXME: Add info
-        for info, states in groupby_attribute(component.states, "info").items():
-            text += start_odeblock("states", name=name, info=info) + "\n"
-            text += ", ".join([print_ScalarParam(s) for s in states])
-            text += "\n)\n"
-
-        if name is not None:
-            text += f'expressions("{name}")\n'
-
-        text += "\n".join([print_assignment(a) for a in component.assignments])
-
+    text += printer.print_comments()
+    text += printer.print_states()
+    text += printer.print_parameters()
+    text += printer.print_assignments()
     path.write_text(text)

--- a/tests/cellml_files/ToRORd_dynCl_mid.cellml
+++ b/tests/cellml_files/ToRORd_dynCl_mid.cellml
@@ -1,0 +1,9497 @@
+<?xml version='1.0'?>
+<!--
+Tomek ... human cardiac ventricular action potential model:
+- original implementation: 17/11/2018, Alfonso Bueno-Orovio, University of Oxford
+- Reference:
+Journal. Year;Volume(Issue):Pages. doi:
+Title.
+Authors.
+
+This code makes use of portions of a previous implementation of the O'Hara-Vir-->
+<model cmeta:id="ToRORd_dyn_chloride" name="ToRORd_dyn_chloride" xmlns="http://www.cellml.org/cellml/1.0#" xmlns:cellml="http://www.cellml.org/cellml/1.0#" xmlns:cmeta="http://www.cellml.org/metadata/1.0#">
+    <units name="millisecond">
+        <unit prefix="milli" units="second"/>
+    </units>
+    <units name="per_millisecond">
+        <unit exponent="-1" units="millisecond"/>
+    </units>
+    <units name="millivolt">
+        <unit prefix="milli" units="volt"/>
+    </units>
+    <units name="millivolt_per_millimole">
+        <unit prefix="milli" units="volt"/>
+        <unit exponent="-1" units="millimolar"/>
+    </units>
+    <units name="per_millivolt">
+        <unit exponent="-1" units="millivolt"/>
+    </units>
+    <units name="per_millivolt_millisecond">
+        <unit exponent="-1" units="millivolt"/>
+        <unit exponent="-1" units="millisecond"/>
+    </units>
+    <units name="millimolar">
+        <unit prefix="milli" units="mole"/>
+        <unit exponent="-1" units="litre"/>
+    </units>
+    <units name="per_millimolar">
+        <unit exponent="-1" units="millimolar"/>
+    </units>
+    <units name="millimolar_per_millisecond">
+        <unit units="millimolar"/>
+        <unit exponent="-1" units="millisecond"/>
+    </units>
+    <units name="per_millimolar_per_millisecond">
+        <unit exponent="-1" units="millimolar"/>
+        <unit exponent="-1" units="millisecond"/>
+    </units>
+    <units name="millisecond_per_millimolar">
+        <unit units="millisecond"/>
+        <unit exponent="-1" units="millimolar"/>
+    </units>
+    <units name="picoA">
+        <unit prefix="pico" units="ampere"/>
+    </units>
+    <units name="microA_per_microF">
+        <unit prefix="micro" units="ampere"/>
+        <unit exponent="-1" prefix="micro" units="farad"/>
+    </units>
+    <units name="microC_per_microF">
+        <unit prefix="micro" units="coulomb"/>
+        <unit exponent="-1" prefix="micro" units="farad"/>
+    </units>
+    <units name="milliS_per_microF">
+        <unit prefix="milli" units="siemens"/>
+        <unit exponent="-1" prefix="micro" units="farad"/>
+    </units>
+    <units name="microF">
+        <unit prefix="micro" units="farad"/>
+    </units>
+    <units name="micrometre_3">
+        <unit exponent="3" prefix="micro" units="metre"/>
+    </units>
+    <units name="per_micrometre_3">
+        <unit exponent="-3" prefix="micro" units="metre"/>
+    </units>
+    <units name="mm2">
+        <unit exponent="2" prefix="milli" units="metre"/>
+    </units>
+    <units name="centimeter">
+        <unit prefix="centi" units="metre"/>
+    </units>
+    <units name="centimeter_squared">
+        <unit exponent="2" units="centimeter"/>
+    </units>
+    <units name="microliter_per_centimeter_cubed">
+        <unit units="microliter"/>
+        <unit exponent="-3" units="centimeter"/>
+    </units>
+    <units name="microF_per_centimeter_squared">
+        <unit units="microF"/>
+        <unit exponent="-1" units="centimeter_squared"/>
+    </units>
+    <units name="microliter">
+        <unit prefix="micro" units="liter"/>
+    </units>
+    <units name="joule_per_kilomole_kelvin">
+        <unit units="joule"/>
+        <unit exponent="-1" prefix="kilo" units="mole"/>
+        <unit exponent="-1" units="kelvin"/>
+    </units>
+    <units name="coulomb_per_mole">
+        <unit units="coulomb"/>
+        <unit exponent="-1" units="mole"/>
+    </units>
+    <units name="per_kelvin">
+        <unit exponent="-1" units="kelvin"/>
+    </units>
+    <component name="environment">
+        <variable cmeta:id="time" name="time" public_interface="out" units="millisecond"/>
+        <variable initial_value="2" name="celltype" public_interface="out" units="dimensionless"/>
+    </component>
+    <component name="extracellular">
+        <variable cmeta:id="extracellular_sodium_concentration" initial_value="140.0" name="nao" public_interface="out" units="millimolar"/>
+        <variable cmeta:id="extracellular_calcium_concentration" initial_value="1.8" name="cao" public_interface="out" units="millimolar"/>
+        <variable cmeta:id="extracellular_potassium_concentration" initial_value="5.0" name="ko" public_interface="out" units="millimolar"/>
+        <variable cmeta:id="extracellular_chloride_concentration" initial_value="150.0" name="clo" public_interface="out" units="millimolar"/>
+    </component>
+    <component name="physical_constants">
+        <variable initial_value="8314" name="R" public_interface="out" units="joule_per_kilomole_kelvin"/>
+        <variable initial_value="310" name="T" public_interface="out" units="kelvin"/>
+        <variable initial_value="96485" name="F" public_interface="out" units="coulomb_per_mole"/>
+        <variable initial_value="1" name="zna" public_interface="out" units="dimensionless"/>
+        <variable initial_value="2" name="zca" public_interface="out" units="dimensionless"/>
+        <variable initial_value="1" name="zk" public_interface="out" units="dimensionless"/>
+        <variable initial_value="-1" name="zcl" public_interface="out" units="dimensionless"/>
+    </component>
+    <component name="cell_geometry">
+        <variable initial_value="0.01" name="L" units="centimeter"/>
+        <variable initial_value="0.0011" name="rad" units="centimeter"/>
+        <variable name="vcell" public_interface="out" units="microliter"/>
+        <variable name="Ageo" public_interface="out" units="centimeter_squared"/>
+        <variable name="Acap" public_interface="out" units="centimeter_squared"/>
+        <variable name="vmyo" public_interface="out" units="microliter"/>
+        <variable name="vnsr" public_interface="out" units="microliter"/>
+        <variable name="vjsr" public_interface="out" units="microliter"/>
+        <variable name="vss" public_interface="out" units="microliter"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>vcell</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="microliter_per_centimeter_cubed">1000</cn>
+                    <cn cellml:units="dimensionless">3.14</cn>
+                    <ci>rad</ci>
+                    <ci>rad</ci>
+                    <ci>L</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Ageo</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">2</cn>
+                        <cn cellml:units="dimensionless">3.14</cn>
+                        <ci>rad</ci>
+                        <ci>rad</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">2</cn>
+                        <cn cellml:units="dimensionless">3.14</cn>
+                        <ci>rad</ci>
+                        <ci>L</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Acap</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless">2</cn>
+                    <ci>Ageo</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>vmyo</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless">0.68</cn>
+                    <ci>vcell</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>vnsr</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless">0.0552</cn>
+                    <ci>vcell</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>vjsr</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless">0.0048</cn>
+                    <ci>vcell</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>vss</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless">0.02</cn>
+                    <ci>vcell</ci>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="membrane">
+        <variable cmeta:id="membrane_voltage" initial_value="-9.133918e+01" name="v" public_interface="out" units="millivolt"/>
+        <variable name="time" public_interface="in" units="millisecond"/>
+        <variable name="R" public_interface="in" units="joule_per_kilomole_kelvin"/>
+        <variable name="T" public_interface="in" units="kelvin"/>
+        <variable name="F" public_interface="in" units="coulomb_per_mole"/>
+        <variable name="vffrt" public_interface="out" units="coulomb_per_mole"/>
+        <variable name="vfrt" public_interface="out" units="dimensionless"/>
+        <variable name="INa" public_interface="in" units="microA_per_microF"/>
+        <variable name="INaL" public_interface="in" units="microA_per_microF"/>
+        <variable name="Ito" public_interface="in" units="microA_per_microF"/>
+        <variable name="ICaL" public_interface="in" units="microA_per_microF"/>
+        <variable name="ICaNa" public_interface="in" units="microA_per_microF"/>
+        <variable name="ICaK" public_interface="in" units="microA_per_microF"/>
+        <variable name="IKr" public_interface="in" units="microA_per_microF"/>
+        <variable name="IKs" public_interface="in" units="microA_per_microF"/>
+        <variable name="IK1" public_interface="in" units="microA_per_microF"/>
+        <variable name="INaCa_i" public_interface="in" units="microA_per_microF"/>
+        <variable name="INaCa_ss" public_interface="in" units="microA_per_microF"/>
+        <variable name="INaK" public_interface="in" units="microA_per_microF"/>
+        <variable name="INab" public_interface="in" units="microA_per_microF"/>
+        <variable name="IKb" public_interface="in" units="microA_per_microF"/>
+        <variable name="IpCa" public_interface="in" units="microA_per_microF"/>
+        <variable name="ICab" public_interface="in" units="microA_per_microF"/>
+        <variable name="IClCa" public_interface="in" units="microA_per_microF"/>
+        <variable name="IClb" public_interface="in" units="microA_per_microF"/>
+        <variable name="I_katp" public_interface="in" units="microA_per_microF"/>
+        <variable cmeta:id="membrane_stimulus_current" name="Istim" public_interface="out" units="microA_per_microF"/>
+        <variable cmeta:id="membrane_stimulus_current_offset" initial_value="0" name="i_Stim_Start" units="millisecond"/>
+        <variable initial_value="100000000000000000" name="i_Stim_End" units="millisecond"/>
+        <variable cmeta:id="membrane_stimulus_current_amplitude" initial_value="-53" name="i_Stim_Amplitude" units="microA_per_microF"/>
+        <variable cmeta:id="membrane_stimulus_current_period" initial_value="1000" name="i_Stim_Period" units="millisecond"/>
+        <variable cmeta:id="membrane_stimulus_current_duration" initial_value="1.0" name="i_Stim_PulseDuration" units="millisecond"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>Istim</ci>
+                <piecewise>
+                    <piece>
+                        <ci>i_Stim_Amplitude</ci>
+                        <apply>
+                            <and/>
+                            <apply>
+                                <geq/>
+                                <ci>time</ci>
+                                <ci>i_Stim_Start</ci>
+                            </apply>
+                            <apply>
+                                <leq/>
+                                <apply>
+                                    <minus/>
+                                    <apply>
+                                        <minus/>
+                                        <ci>time</ci>
+                                        <ci>i_Stim_Start</ci>
+                                    </apply>
+                                    <apply>
+                                        <times/>
+                                        <apply>
+                                            <floor/>
+                                            <apply>
+                                                <divide/>
+                                                <apply>
+                                                    <minus/>
+                                                    <ci>time</ci>
+                                                    <ci>i_Stim_Start</ci>
+                                                </apply>
+                                                <ci>i_Stim_Period</ci>
+                                            </apply>
+                                        </apply>
+                                        <ci>i_Stim_Period</ci>
+                                    </apply>
+                                </apply>
+                                <ci>i_Stim_PulseDuration</ci>
+                            </apply>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <cn cellml:units="microA_per_microF">0</cn>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>vffrt</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>v</ci>
+                        <ci>F</ci>
+                        <ci>F</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>R</ci>
+                        <ci>T</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>vfrt</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>v</ci>
+                        <ci>F</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>R</ci>
+                        <ci>T</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>v</ci>
+                </apply>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <plus/>
+                        <ci>INa</ci>
+                        <ci>INaL</ci>
+                        <ci>Ito</ci>
+                        <ci>ICaL</ci>
+                        <ci>ICaNa</ci>
+                        <ci>ICaK</ci>
+                        <ci>IKr</ci>
+                        <ci>IKs</ci>
+                        <ci>IK1</ci>
+                        <ci>INaCa_i</ci>
+                        <ci>INaCa_ss</ci>
+                        <ci>INaK</ci>
+                        <ci>INab</ci>
+                        <ci>IKb</ci>
+                        <ci>IpCa</ci>
+                        <ci>ICab</ci>
+                        <ci>IClCa</ci>
+                        <ci>IClb</ci>
+                        <ci>I_katp</ci>
+                        <ci>Istim</ci>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="CaMK">
+        <variable initial_value="0.15" name="KmCaMK" public_interface="out" units="millimolar"/>
+        <variable cmeta:id="aCaMK_var" initial_value="0.05" name="aCaMK" units="per_millimolar_per_millisecond"/>
+        <variable initial_value="0.00068" name="bCaMK" units="per_millisecond"/>
+        <variable cmeta:id="CaMKo_var" initial_value="0.05" name="CaMKo" units="dimensionless"/>
+        <variable initial_value="0.0015" name="KmCaM" units="millimolar"/>
+        <variable name="CaMKb" public_interface="out" units="millimolar"/>
+        <variable name="CaMKa" public_interface="out" units="millimolar"/>
+        <variable initial_value="2.018820e-02" name="CaMKt" units="millimolar"/>
+        <variable name="cass" public_interface="in" units="millimolar"/>
+        <variable name="time" public_interface="in" units="millisecond"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>CaMKb</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>CaMKo</ci>
+                        <apply>
+                            <minus/>
+                            <cn cellml:units="millimolar">1</cn>
+                            <ci>CaMKt</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <divide/>
+                            <ci>KmCaM</ci>
+                            <ci>cass</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>CaMKa</ci>
+                <apply>
+                    <plus/>
+                    <ci>CaMKb</ci>
+                    <ci>CaMKt</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>CaMKt</ci>
+                </apply>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <times/>
+                        <ci>aCaMK</ci>
+                        <ci>CaMKb</ci>
+                        <apply>
+                            <plus/>
+                            <ci>CaMKb</ci>
+                            <ci>CaMKt</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>bCaMK</ci>
+                        <ci>CaMKt</ci>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="intracellular_ions">
+        <variable initial_value="0.05" name="cmdnmax_b" units="millimolar"/>
+        <variable name="cmdnmax" units="millimolar"/>
+        <variable initial_value="0.00238" name="kmcmdn" units="millimolar"/>
+        <variable initial_value="0.07" name="trpnmax" units="millimolar"/>
+        <variable initial_value="0.0005" name="kmtrpn" units="millimolar"/>
+        <variable initial_value="0.047" name="BSRmax" units="millimolar"/>
+        <variable initial_value="0.00087" name="KmBSR" units="millimolar"/>
+        <variable initial_value="1.124" name="BSLmax" units="millimolar"/>
+        <variable initial_value="0.0087" name="KmBSL" units="millimolar"/>
+        <variable initial_value="10" name="csqnmax" units="millimolar"/>
+        <variable initial_value="0.8" name="kmcsqn" units="millimolar"/>
+        <variable cmeta:id="cytosolic_sodium_concentration" initial_value="1.594867e+01" name="nai" public_interface="out" units="millimolar"/>
+        <variable initial_value="1.594922e+01" name="nass" public_interface="out" units="millimolar"/>
+        <variable cmeta:id="cytosolic_potassium_concentration" initial_value="1.567131e+02" name="ki" public_interface="out" units="millimolar"/>
+        <variable initial_value="1.567130e+02" name="kss" public_interface="out" units="millimolar"/>
+        <variable initial_value="6.642187e-05" name="cass" public_interface="out" units="millimolar"/>
+        <variable initial_value="2.012225e+00" name="cansr" public_interface="out" units="millimolar"/>
+        <variable initial_value="2.016415e+00" name="cajsr" public_interface="out" units="millimolar"/>
+        <variable cmeta:id="cytosolic_calcium_concentration" initial_value="8.297576e-05" name="cai" public_interface="out" units="millimolar"/>
+        <variable cmeta:id="cytosolic_chloride_concentration" initial_value="4.891277e+01" name="cli" public_interface="out" units="millimolar"/>
+        <variable initial_value="4.891274e+01" name="clss" public_interface="out" units="millimolar"/>
+        <variable name="celltype" public_interface="in" units="dimensionless"/>
+        <variable name="Acap" public_interface="in" units="centimeter_squared"/>
+        <variable name="R" public_interface="in" units="joule_per_kilomole_kelvin"/>
+        <variable name="T" public_interface="in" units="kelvin"/>
+        <variable name="F" public_interface="in" units="coulomb_per_mole"/>
+        <variable name="INa" public_interface="in" units="microA_per_microF"/>
+        <variable name="INaL" public_interface="in" units="microA_per_microF"/>
+        <variable name="INaCa_i" public_interface="in" units="microA_per_microF"/>
+        <variable name="INaCa_ss" public_interface="in" units="microA_per_microF"/>
+        <variable name="ICaL" public_interface="in" units="microA_per_microF"/>
+        <variable name="ICaNa" public_interface="in" units="microA_per_microF"/>
+        <variable name="ICaK" public_interface="in" units="microA_per_microF"/>
+        <variable name="ICaL_ss" public_interface="in" units="microA_per_microF"/>
+        <variable name="ICaNa_ss" public_interface="in" units="microA_per_microF"/>
+        <variable name="ICaK_ss" public_interface="in" units="microA_per_microF"/>
+        <variable name="ICaL_i" public_interface="in" units="microA_per_microF"/>
+        <variable name="ICaNa_i" public_interface="in" units="microA_per_microF"/>
+        <variable name="ICaK_i" public_interface="in" units="microA_per_microF"/>
+        <variable name="INaK" public_interface="in" units="microA_per_microF"/>
+        <variable name="INab" public_interface="in" units="microA_per_microF"/>
+        <variable name="IK1" public_interface="in" units="microA_per_microF"/>
+        <variable name="IKb" public_interface="in" units="microA_per_microF"/>
+        <variable name="IKr" public_interface="in" units="microA_per_microF"/>
+        <variable name="IKs" public_interface="in" units="microA_per_microF"/>
+        <variable name="Istim" public_interface="in" units="microA_per_microF"/>
+        <variable name="Ito" public_interface="in" units="microA_per_microF"/>
+        <variable name="I_katp" public_interface="in" units="microA_per_microF"/>
+        <variable name="ICab" public_interface="in" units="microA_per_microF"/>
+        <variable name="IpCa" public_interface="in" units="microA_per_microF"/>
+        <variable name="JdiffNa" public_interface="in" units="millimolar_per_millisecond"/>
+        <variable name="Jdiff" public_interface="in" units="millimolar_per_millisecond"/>
+        <variable name="Jup" public_interface="in" units="millimolar_per_millisecond"/>
+        <variable name="JdiffK" public_interface="in" units="millimolar_per_millisecond"/>
+        <variable name="JdiffCl" public_interface="in" units="millimolar_per_millisecond"/>
+        <variable name="Jrel" public_interface="in" units="millimolar_per_millisecond"/>
+        <variable name="Jtr" public_interface="in" units="millimolar_per_millisecond"/>
+        <variable name="time" public_interface="in" units="millisecond"/>
+        <variable name="vmyo" public_interface="in" units="microliter"/>
+        <variable name="vnsr" public_interface="in" units="microliter"/>
+        <variable name="vss" public_interface="in" units="microliter"/>
+        <variable name="vjsr" public_interface="in" units="microliter"/>
+        <variable name="Bcai" units="dimensionless"/>
+        <variable name="Bcajsr" units="dimensionless"/>
+        <variable name="Bcass" units="dimensionless"/>
+        <variable name="IClCa" public_interface="in" units="microA_per_microF"/>
+        <variable name="IClCa_sl" public_interface="in" units="microA_per_microF"/>
+        <variable name="IClCa_junc" public_interface="in" units="microA_per_microF"/>
+        <variable name="IClb" public_interface="in" units="microA_per_microF"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>cmdnmax</ci>
+                <piecewise>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>cmdnmax_b</ci>
+                            <cn cellml:units="dimensionless">1.3</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">1</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <ci>cmdnmax_b</ci>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>nai</ci>
+                </apply>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <apply>
+                                    <plus/>
+                                    <ci>INa</ci>
+                                    <ci>INaL</ci>
+                                    <apply>
+                                        <times/>
+                                        <cn cellml:units="dimensionless">3</cn>
+                                        <ci>INaCa_i</ci>
+                                    </apply>
+                                    <ci>ICaNa_i</ci>
+                                    <apply>
+                                        <times/>
+                                        <cn cellml:units="dimensionless">3</cn>
+                                        <ci>INaK</ci>
+                                    </apply>
+                                    <ci>INab</ci>
+                                </apply>
+                            </apply>
+                            <ci>Acap</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>F</ci>
+                            <ci>vmyo</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <ci>JdiffNa</ci>
+                            <ci>vss</ci>
+                        </apply>
+                        <ci>vmyo</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>nass</ci>
+                </apply>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <apply>
+                                    <plus/>
+                                    <ci>ICaNa_ss</ci>
+                                    <apply>
+                                        <times/>
+                                        <cn cellml:units="dimensionless">3</cn>
+                                        <ci>INaCa_ss</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <ci>Acap</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>F</ci>
+                            <ci>vss</ci>
+                        </apply>
+                    </apply>
+                    <ci>JdiffNa</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>ki</ci>
+                </apply>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <apply>
+                                    <plus/>
+                                    <apply>
+                                        <minus/>
+                                        <apply>
+                                            <plus/>
+                                            <ci>Ito</ci>
+                                            <ci>IKr</ci>
+                                            <ci>IKs</ci>
+                                            <ci>IK1</ci>
+                                            <ci>IKb</ci>
+                                            <ci>I_katp</ci>
+                                            <ci>Istim</ci>
+                                        </apply>
+                                        <apply>
+                                            <times/>
+                                            <cn cellml:units="dimensionless">2</cn>
+                                            <ci>INaK</ci>
+                                        </apply>
+                                    </apply>
+                                    <ci>ICaK_i</ci>
+                                </apply>
+                            </apply>
+                            <ci>Acap</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>F</ci>
+                            <ci>vmyo</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <ci>JdiffK</ci>
+                            <ci>vss</ci>
+                        </apply>
+                        <ci>vmyo</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>kss</ci>
+                </apply>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <ci>ICaK_ss</ci>
+                            </apply>
+                            <ci>Acap</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>F</ci>
+                            <ci>vss</ci>
+                        </apply>
+                    </apply>
+                    <ci>JdiffK</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>cli</ci>
+                </apply>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <plus/>
+                                <ci>IClb</ci>
+                                <ci>IClCa_sl</ci>
+                            </apply>
+                            <ci>Acap</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>F</ci>
+                            <ci>vmyo</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <ci>JdiffCl</ci>
+                            <ci>vss</ci>
+                        </apply>
+                        <ci>vmyo</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>clss</ci>
+                </apply>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <ci>IClCa_junc</ci>
+                            <ci>Acap</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>F</ci>
+                            <ci>vss</ci>
+                        </apply>
+                    </apply>
+                    <ci>JdiffCl</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Bcai</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <divide/>
+                            <apply>
+                                <times/>
+                                <ci>cmdnmax</ci>
+                                <ci>kmcmdn</ci>
+                            </apply>
+                            <apply>
+                                <power/>
+                                <apply>
+                                    <plus/>
+                                    <ci>kmcmdn</ci>
+                                    <ci>cai</ci>
+                                </apply>
+                                <cn cellml:units="dimensionless">2</cn>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <divide/>
+                            <apply>
+                                <times/>
+                                <ci>trpnmax</ci>
+                                <ci>kmtrpn</ci>
+                            </apply>
+                            <apply>
+                                <power/>
+                                <apply>
+                                    <plus/>
+                                    <ci>kmtrpn</ci>
+                                    <ci>cai</ci>
+                                </apply>
+                                <cn cellml:units="dimensionless">2</cn>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>cai</ci>
+                </apply>
+                <apply>
+                    <times/>
+                    <ci>Bcai</ci>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <times/>
+                                    <apply>
+                                        <minus/>
+                                        <apply>
+                                            <minus/>
+                                            <apply>
+                                                <plus/>
+                                                <ci>ICaL_i</ci>
+                                                <ci>IpCa</ci>
+                                                <ci>ICab</ci>
+                                            </apply>
+                                            <apply>
+                                                <times/>
+                                                <cn cellml:units="dimensionless">2</cn>
+                                                <ci>INaCa_i</ci>
+                                            </apply>
+                                        </apply>
+                                    </apply>
+                                    <ci>Acap</ci>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <cn cellml:units="dimensionless">2</cn>
+                                    <ci>F</ci>
+                                    <ci>vmyo</ci>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <times/>
+                                    <ci>Jup</ci>
+                                    <ci>vnsr</ci>
+                                </apply>
+                                <ci>vmyo</ci>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <divide/>
+                            <apply>
+                                <times/>
+                                <ci>Jdiff</ci>
+                                <ci>vss</ci>
+                            </apply>
+                            <ci>vmyo</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Bcass</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <divide/>
+                            <apply>
+                                <times/>
+                                <ci>BSRmax</ci>
+                                <ci>KmBSR</ci>
+                            </apply>
+                            <apply>
+                                <power/>
+                                <apply>
+                                    <plus/>
+                                    <ci>KmBSR</ci>
+                                    <ci>cass</ci>
+                                </apply>
+                                <cn cellml:units="dimensionless">2</cn>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <divide/>
+                            <apply>
+                                <times/>
+                                <ci>BSLmax</ci>
+                                <ci>KmBSL</ci>
+                            </apply>
+                            <apply>
+                                <power/>
+                                <apply>
+                                    <plus/>
+                                    <ci>KmBSL</ci>
+                                    <ci>cass</ci>
+                                </apply>
+                                <cn cellml:units="dimensionless">2</cn>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>cass</ci>
+                </apply>
+                <apply>
+                    <times/>
+                    <ci>Bcass</ci>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <times/>
+                                    <apply>
+                                        <minus/>
+                                        <apply>
+                                            <minus/>
+                                            <ci>ICaL_ss</ci>
+                                            <apply>
+                                                <times/>
+                                                <cn cellml:units="dimensionless">2</cn>
+                                                <ci>INaCa_ss</ci>
+                                            </apply>
+                                        </apply>
+                                    </apply>
+                                    <ci>Acap</ci>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <cn cellml:units="dimensionless">2</cn>
+                                    <ci>F</ci>
+                                    <ci>vss</ci>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <times/>
+                                    <ci>Jrel</ci>
+                                    <ci>vjsr</ci>
+                                </apply>
+                                <ci>vss</ci>
+                            </apply>
+                        </apply>
+                        <ci>Jdiff</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>cansr</ci>
+                </apply>
+                <apply>
+                    <minus/>
+                    <ci>Jup</ci>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <ci>Jtr</ci>
+                            <ci>vjsr</ci>
+                        </apply>
+                        <ci>vnsr</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Bcajsr</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <divide/>
+                            <apply>
+                                <times/>
+                                <ci>csqnmax</ci>
+                                <ci>kmcsqn</ci>
+                            </apply>
+                            <apply>
+                                <power/>
+                                <apply>
+                                    <plus/>
+                                    <ci>kmcsqn</ci>
+                                    <ci>cajsr</ci>
+                                </apply>
+                                <cn cellml:units="dimensionless">2</cn>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>cajsr</ci>
+                </apply>
+                <apply>
+                    <times/>
+                    <ci>Bcajsr</ci>
+                    <apply>
+                        <minus/>
+                        <ci>Jtr</ci>
+                        <ci>Jrel</ci>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="reversal_potentials">
+        <variable initial_value="0.01833" name="PKNa" units="dimensionless"/>
+        <variable name="ENa" public_interface="out" units="millivolt"/>
+        <variable name="EK" public_interface="out" units="millivolt"/>
+        <variable name="EKs" public_interface="out" units="millivolt"/>
+        <variable name="ECl" public_interface="out" units="millivolt"/>
+        <variable name="EClss" public_interface="out" units="millivolt"/>
+        <variable name="nao" public_interface="in" units="millimolar"/>
+        <variable name="nai" public_interface="in" units="millimolar"/>
+        <variable name="ko" public_interface="in" units="millimolar"/>
+        <variable name="ki" public_interface="in" units="millimolar"/>
+        <variable name="clo" public_interface="in" units="millimolar"/>
+        <variable name="cli" public_interface="in" units="millimolar"/>
+        <variable name="clss" public_interface="in" units="millimolar"/>
+        <variable name="zna" public_interface="in" units="dimensionless"/>
+        <variable name="zk" public_interface="in" units="dimensionless"/>
+        <variable name="zcl" public_interface="in" units="dimensionless"/>
+        <variable name="R" public_interface="in" units="joule_per_kilomole_kelvin"/>
+        <variable name="T" public_interface="in" units="kelvin"/>
+        <variable name="F" public_interface="in" units="coulomb_per_mole"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>ENa</ci>
+                <apply>
+                    <times/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <ci>R</ci>
+                            <ci>T</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>zna</ci>
+                            <ci>F</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <ln/>
+                        <apply>
+                            <divide/>
+                            <ci>nao</ci>
+                            <ci>nai</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>EK</ci>
+                <apply>
+                    <times/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <ci>R</ci>
+                            <ci>T</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>zk</ci>
+                            <ci>F</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <ln/>
+                        <apply>
+                            <divide/>
+                            <ci>ko</ci>
+                            <ci>ki</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>EKs</ci>
+                <apply>
+                    <times/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <ci>R</ci>
+                            <ci>T</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>zk</ci>
+                            <ci>F</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <ln/>
+                        <apply>
+                            <divide/>
+                            <apply>
+                                <plus/>
+                                <ci>ko</ci>
+                                <apply>
+                                    <times/>
+                                    <ci>PKNa</ci>
+                                    <ci>nao</ci>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <plus/>
+                                <ci>ki</ci>
+                                <apply>
+                                    <times/>
+                                    <ci>PKNa</ci>
+                                    <ci>nai</ci>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>ECl</ci>
+                <apply>
+                    <times/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <ci>R</ci>
+                            <ci>T</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>zcl</ci>
+                            <ci>F</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <ln/>
+                        <apply>
+                            <divide/>
+                            <ci>clo</ci>
+                            <ci>cli</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>EClss</ci>
+                <apply>
+                    <times/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <ci>R</ci>
+                            <ci>T</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>zcl</ci>
+                            <ci>F</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <ln/>
+                        <apply>
+                            <divide/>
+                            <ci>clo</ci>
+                            <ci>clss</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="I_katp">
+        <variable name="v" public_interface="in" units="millivolt"/>
+        <variable name="EK" public_interface="in" units="millivolt"/>
+        <variable name="ko" public_interface="in" units="millimolar"/>
+        <variable initial_value="4.3195" name="gkatp" units="milliS_per_microF"/>
+        <variable cmeta:id="membrane_atp_dependent_potassium_current_conductance" initial_value="0.0" name="fkatp" units="dimensionless"/>
+        <variable initial_value="5" name="K_o_n" units="millimolar"/>
+        <variable initial_value="2" name="A_atp" units="millimolar"/>
+        <variable initial_value="0.25" name="K_atp" units="millimolar"/>
+        <variable name="akik" units="dimensionless"/>
+        <variable name="bkik" units="dimensionless"/>
+        <variable cmeta:id="membrane_atp_dependent_potassium_current" name="I_katp" public_interface="out" units="microA_per_microF"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>akik</ci>
+                <apply>
+                    <power/>
+                    <apply>
+                        <divide/>
+                        <ci>ko</ci>
+                        <ci>K_o_n</ci>
+                    </apply>
+                    <cn cellml:units="dimensionless">0.24</cn>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>bkik</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <power/>
+                            <apply>
+                                <divide/>
+                                <ci>A_atp</ci>
+                                <ci>K_atp</ci>
+                            </apply>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>I_katp</ci>
+                <apply>
+                    <times/>
+                    <ci>fkatp</ci>
+                    <ci>gkatp</ci>
+                    <ci>akik</ci>
+                    <ci>bkik</ci>
+                    <apply>
+                        <minus/>
+                        <ci>v</ci>
+                        <ci>EK</ci>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="INa">
+        <variable name="mss" units="dimensionless"/>
+        <variable name="tm" public_interface="out" units="millisecond"/>
+        <variable initial_value="4.619565e-04" name="m" units="dimensionless"/>
+        <variable name="hss" units="dimensionless"/>
+        <variable name="ah" units="dimensionless"/>
+        <variable name="bh" units="dimensionless"/>
+        <variable name="th" units="millisecond"/>
+        <variable initial_value="8.739077e-01" name="h" units="dimensionless"/>
+        <variable name="jss" units="dimensionless"/>
+        <variable name="aj" units="dimensionless"/>
+        <variable name="bj" units="dimensionless"/>
+        <variable name="tj" units="millisecond"/>
+        <variable initial_value="8.737841e-01" name="j" units="dimensionless"/>
+        <variable name="hssp" units="dimensionless"/>
+        <variable initial_value="7.478972e-01" name="hp" units="dimensionless"/>
+        <variable name="tjp" units="millisecond"/>
+        <variable initial_value="8.735375e-01" name="jp" units="dimensionless"/>
+        <variable name="fINap" units="dimensionless"/>
+        <variable name="time" public_interface="in" units="millisecond"/>
+        <variable name="v" public_interface="in" units="millivolt"/>
+        <variable name="KmCaMK" public_interface="in" units="millimolar"/>
+        <variable name="CaMKa" public_interface="in" units="millimolar"/>
+        <variable name="ENa" public_interface="in" units="millivolt"/>
+        <variable cmeta:id="membrane_fast_sodium_current_conductance" initial_value="11.7802" name="GNa" units="milliS_per_microF"/>
+        <variable cmeta:id="membrane_fast_sodium_current" name="INa" public_interface="out" units="microA_per_microF"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>mss</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <power/>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <exp/>
+                                <apply>
+                                    <divide/>
+                                    <apply>
+                                        <minus/>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <cn cellml:units="millivolt">56.86</cn>
+                                        </apply>
+                                    </apply>
+                                    <cn cellml:units="millivolt">9.03</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">2</cn>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tm</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="millisecond">0.1292</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <minus/>
+                                <apply>
+                                    <power/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <cn cellml:units="millivolt">45.79</cn>
+                                        </apply>
+                                        <cn cellml:units="millivolt">15.54</cn>
+                                    </apply>
+                                    <cn cellml:units="dimensionless">2</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="millisecond">0.06487</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <minus/>
+                                <apply>
+                                    <power/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <minus/>
+                                            <ci>v</ci>
+                                            <cn cellml:units="millivolt">4.823</cn>
+                                        </apply>
+                                        <cn cellml:units="millivolt">51.12</cn>
+                                    </apply>
+                                    <cn cellml:units="dimensionless">2</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>m</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>mss</ci>
+                        <ci>m</ci>
+                    </apply>
+                    <ci>tm</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>hss</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <power/>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <exp/>
+                                <apply>
+                                    <divide/>
+                                    <apply>
+                                        <plus/>
+                                        <ci>v</ci>
+                                        <cn cellml:units="millivolt">71.55</cn>
+                                    </apply>
+                                    <cn cellml:units="millivolt">7.43</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">2</cn>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>ah</ci>
+                <piecewise>
+                    <piece>
+                        <cn cellml:units="dimensionless">0</cn>
+                        <apply>
+                            <geq/>
+                            <ci>v</ci>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="millivolt">40</cn>
+                            </apply>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <apply>
+                            <times/>
+                            <cn cellml:units="dimensionless">0.057</cn>
+                            <apply>
+                                <exp/>
+                                <apply>
+                                    <divide/>
+                                    <apply>
+                                        <minus/>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <cn cellml:units="millivolt">80</cn>
+                                        </apply>
+                                    </apply>
+                                    <cn cellml:units="millivolt">6.8</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>bh</ci>
+                <piecewise>
+                    <piece>
+                        <apply>
+                            <divide/>
+                            <cn cellml:units="dimensionless">0.77</cn>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.13</cn>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <exp/>
+                                        <apply>
+                                            <divide/>
+                                            <apply>
+                                                <minus/>
+                                                <apply>
+                                                    <plus/>
+                                                    <ci>v</ci>
+                                                    <cn cellml:units="millivolt">10.66</cn>
+                                                </apply>
+                                            </apply>
+                                            <cn cellml:units="millivolt">11.1</cn>
+                                        </apply>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <geq/>
+                            <ci>v</ci>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="millivolt">40</cn>
+                            </apply>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">2.7</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <times/>
+                                        <cn cellml:units="per_millivolt">0.079</cn>
+                                        <ci>v</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless" type="e-notation">3.1<sep/>5</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <times/>
+                                        <cn cellml:units="per_millivolt">0.3485</cn>
+                                        <ci>v</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>th</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="millisecond">1</cn>
+                    <apply>
+                        <plus/>
+                        <ci>ah</ci>
+                        <ci>bh</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>h</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>hss</ci>
+                        <ci>h</ci>
+                    </apply>
+                    <ci>th</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>aj</ci>
+                <piecewise>
+                    <piece>
+                        <cn cellml:units="dimensionless">0</cn>
+                        <apply>
+                            <geq/>
+                            <ci>v</ci>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="millivolt">40</cn>
+                            </apply>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <apply>
+                            <divide/>
+                            <apply>
+                                <times/>
+                                <apply>
+                                    <minus/>
+                                    <apply>
+                                        <times/>
+                                        <apply>
+                                            <minus/>
+                                            <cn cellml:units="per_millivolt" type="e-notation">2.5428<sep/>4</cn>
+                                        </apply>
+                                        <apply>
+                                            <exp/>
+                                            <apply>
+                                                <times/>
+                                                <cn cellml:units="per_millivolt">0.2444</cn>
+                                                <ci>v</ci>
+                                            </apply>
+                                        </apply>
+                                    </apply>
+                                    <apply>
+                                        <times/>
+                                        <cn cellml:units="per_millivolt" type="e-notation">6.948<sep/>-6</cn>
+                                        <apply>
+                                            <exp/>
+                                            <apply>
+                                                <times/>
+                                                <apply>
+                                                    <minus/>
+                                                    <cn cellml:units="per_millivolt">0.04391</cn>
+                                                </apply>
+                                                <ci>v</ci>
+                                            </apply>
+                                        </apply>
+                                    </apply>
+                                </apply>
+                                <apply>
+                                    <plus/>
+                                    <ci>v</ci>
+                                    <cn cellml:units="millivolt">37.78</cn>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <plus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <times/>
+                                        <cn cellml:units="per_millivolt">0.311</cn>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <cn cellml:units="millivolt">79.23</cn>
+                                        </apply>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>bj</ci>
+                <piecewise>
+                    <piece>
+                        <apply>
+                            <divide/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.6</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <times/>
+                                        <cn cellml:units="per_millivolt">0.057</cn>
+                                        <ci>v</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <plus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <times/>
+                                        <apply>
+                                            <minus/>
+                                            <cn cellml:units="per_millivolt">0.1</cn>
+                                        </apply>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <cn cellml:units="millivolt">32</cn>
+                                        </apply>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <geq/>
+                            <ci>v</ci>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="millivolt">40</cn>
+                            </apply>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <apply>
+                            <divide/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.02424</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <times/>
+                                        <apply>
+                                            <minus/>
+                                            <cn cellml:units="per_millivolt">0.01052</cn>
+                                        </apply>
+                                        <ci>v</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <plus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <times/>
+                                        <apply>
+                                            <minus/>
+                                            <cn cellml:units="per_millivolt">0.1378</cn>
+                                        </apply>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <cn cellml:units="millivolt">40.14</cn>
+                                        </apply>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>jss</ci>
+                <ci>hss</ci>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tj</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="millisecond">1</cn>
+                    <apply>
+                        <plus/>
+                        <ci>aj</ci>
+                        <ci>bj</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>j</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>jss</ci>
+                        <ci>j</ci>
+                    </apply>
+                    <ci>tj</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>hssp</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <power/>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <exp/>
+                                <apply>
+                                    <divide/>
+                                    <apply>
+                                        <plus/>
+                                        <ci>v</ci>
+                                        <cn cellml:units="millivolt">77.55</cn>
+                                    </apply>
+                                    <cn cellml:units="millivolt">7.43</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">2</cn>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>hp</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>hssp</ci>
+                        <ci>hp</ci>
+                    </apply>
+                    <ci>th</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tjp</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless">1.46</cn>
+                    <ci>tj</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>jp</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>jss</ci>
+                        <ci>jp</ci>
+                    </apply>
+                    <ci>tjp</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>fINap</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <divide/>
+                            <ci>KmCaMK</ci>
+                            <ci>CaMKa</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>INa</ci>
+                <apply>
+                    <times/>
+                    <ci>GNa</ci>
+                    <apply>
+                        <minus/>
+                        <ci>v</ci>
+                        <ci>ENa</ci>
+                    </apply>
+                    <apply>
+                        <power/>
+                        <ci>m</ci>
+                        <cn cellml:units="dimensionless">3</cn>
+                    </apply>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>fINap</ci>
+                            </apply>
+                            <ci>h</ci>
+                            <ci>j</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>fINap</ci>
+                            <ci>hp</ci>
+                            <ci>jp</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="INaL">
+        <variable name="mLss" units="dimensionless"/>
+        <variable name="tmL" units="millisecond"/>
+        <variable initial_value="9.987709e-05" name="mL" units="dimensionless"/>
+        <variable initial_value="200" name="thL" units="millisecond"/>
+        <variable name="hLss" units="dimensionless"/>
+        <variable name="v" public_interface="in" units="millivolt"/>
+        <variable initial_value="5.986118e-01" name="hL" units="dimensionless"/>
+        <variable name="hLssp" units="dimensionless"/>
+        <variable name="thLp" units="millisecond"/>
+        <variable initial_value="3.339899e-01" name="hLp" units="dimensionless"/>
+        <variable cmeta:id="membrane_persistent_sodium_current_conductance" initial_value="0.0279" name="GNaL_b" units="milliS_per_microF"/>
+        <variable name="GNaL" units="milliS_per_microF"/>
+        <variable name="fINaLp" units="dimensionless"/>
+        <variable name="KmCaMK" public_interface="in" units="millimolar"/>
+        <variable name="CaMKa" public_interface="in" units="millimolar"/>
+        <variable name="ENa" public_interface="in" units="millivolt"/>
+        <variable cmeta:id="membrane_persistent_sodium_current" name="INaL" public_interface="out" units="microA_per_microF"/>
+        <variable name="celltype" public_interface="in" units="dimensionless"/>
+        <variable name="time" public_interface="in" units="millisecond"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>mLss</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <minus/>
+                                    <apply>
+                                        <plus/>
+                                        <ci>v</ci>
+                                        <cn cellml:units="millivolt">42.85</cn>
+                                    </apply>
+                                </apply>
+                                <cn cellml:units="millivolt">5.264</cn>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tmL</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="millisecond">0.1292</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <minus/>
+                                <apply>
+                                    <power/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <cn cellml:units="millivolt">45.79</cn>
+                                        </apply>
+                                        <cn cellml:units="millivolt">15.54</cn>
+                                    </apply>
+                                    <cn cellml:units="dimensionless">2</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="millisecond">0.06487</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <minus/>
+                                <apply>
+                                    <power/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <minus/>
+                                            <ci>v</ci>
+                                            <cn cellml:units="millivolt">4.823</cn>
+                                        </apply>
+                                        <cn cellml:units="millivolt">51.12</cn>
+                                    </apply>
+                                    <cn cellml:units="dimensionless">2</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>mL</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>mLss</ci>
+                        <ci>mL</ci>
+                    </apply>
+                    <ci>tmL</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>hLss</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <plus/>
+                                    <ci>v</ci>
+                                    <cn cellml:units="millivolt">87.61</cn>
+                                </apply>
+                                <cn cellml:units="millivolt">7.488</cn>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>hL</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>hLss</ci>
+                        <ci>hL</ci>
+                    </apply>
+                    <ci>thL</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>hLssp</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <plus/>
+                                    <ci>v</ci>
+                                    <cn cellml:units="millivolt">93.81</cn>
+                                </apply>
+                                <cn cellml:units="millivolt">7.488</cn>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>thLp</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless">3</cn>
+                    <ci>thL</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>hLp</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>hLssp</ci>
+                        <ci>hLp</ci>
+                    </apply>
+                    <ci>thLp</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>GNaL</ci>
+                <piecewise>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>GNaL_b</ci>
+                            <cn cellml:units="dimensionless">0.6</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">1</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <ci>GNaL_b</ci>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>fINaLp</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <divide/>
+                            <ci>KmCaMK</ci>
+                            <ci>CaMKa</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>INaL</ci>
+                <apply>
+                    <times/>
+                    <ci>GNaL</ci>
+                    <apply>
+                        <minus/>
+                        <ci>v</ci>
+                        <ci>ENa</ci>
+                    </apply>
+                    <ci>mL</ci>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>fINaLp</ci>
+                            </apply>
+                            <ci>hL</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>fINaLp</ci>
+                            <ci>hLp</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="Ito">
+        <variable cmeta:id="membrane_transient_outward_current_conductance" initial_value="0.16" name="Gto_b" units="milliS_per_microF"/>
+        <variable name="ass" units="dimensionless"/>
+        <variable name="ta" units="millisecond"/>
+        <variable initial_value="7.994042e-04" name="a" units="dimensionless"/>
+        <variable name="time" public_interface="in" units="millisecond"/>
+        <variable name="v" public_interface="in" units="millivolt"/>
+        <variable initial_value="0" name="EKshift" units="millivolt"/>
+        <variable name="EK" public_interface="in" units="millivolt"/>
+        <variable name="iss" units="dimensionless"/>
+        <variable name="delta_epi" units="dimensionless"/>
+        <variable name="tiF_b" units="millisecond"/>
+        <variable name="tiS_b" units="millisecond"/>
+        <variable name="tiF" units="millisecond"/>
+        <variable name="tiS" units="millisecond"/>
+        <variable name="AiF" units="dimensionless"/>
+        <variable name="AiS" units="dimensionless"/>
+        <variable initial_value="9.997514e-01" name="iF" units="dimensionless"/>
+        <variable initial_value="5.702538e-01" name="iS" units="dimensionless"/>
+        <variable name="i" units="dimensionless"/>
+        <variable name="assp" units="dimensionless"/>
+        <variable initial_value="4.072777e-04" name="ap" units="dimensionless"/>
+        <variable name="dti_develop" units="dimensionless"/>
+        <variable name="dti_recover" units="dimensionless"/>
+        <variable name="tiFp" units="millisecond"/>
+        <variable name="tiSp" units="millisecond"/>
+        <variable initial_value="9.997514e-01" name="iFp" units="dimensionless"/>
+        <variable initial_value="6.351927e-01" name="iSp" units="dimensionless"/>
+        <variable name="ip" units="dimensionless"/>
+        <variable name="Gto" units="milliS_per_microF"/>
+        <variable name="fItop" units="dimensionless"/>
+        <variable cmeta:id="membrane_transient_outward_current" name="Ito" public_interface="out" units="microA_per_microF"/>
+        <variable name="celltype" public_interface="in" units="dimensionless"/>
+        <variable name="KmCaMK" public_interface="in" units="millimolar"/>
+        <variable name="CaMKa" public_interface="in" units="millimolar"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>ass</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <minus/>
+                                    <apply>
+                                        <minus/>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <ci>EKshift</ci>
+                                        </apply>
+                                        <cn cellml:units="millivolt">14.34</cn>
+                                    </apply>
+                                </apply>
+                                <cn cellml:units="millivolt">14.82</cn>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>ta</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="millisecond">1.0515</cn>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <divide/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">1.2089</cn>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <exp/>
+                                        <apply>
+                                            <divide/>
+                                            <apply>
+                                                <minus/>
+                                                <apply>
+                                                    <minus/>
+                                                    <apply>
+                                                        <plus/>
+                                                        <ci>v</ci>
+                                                        <ci>EKshift</ci>
+                                                    </apply>
+                                                    <cn cellml:units="millivolt">18.4099</cn>
+                                                </apply>
+                                            </apply>
+                                            <cn cellml:units="millivolt">29.3814</cn>
+                                        </apply>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <divide/>
+                            <cn cellml:units="dimensionless">3.5</cn>
+                            <apply>
+                                <plus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <ci>EKshift</ci>
+                                            <cn cellml:units="millivolt">100</cn>
+                                        </apply>
+                                        <cn cellml:units="millivolt">29.3814</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>a</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>ass</ci>
+                        <ci>a</ci>
+                    </apply>
+                    <ci>ta</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>iss</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <plus/>
+                                    <ci>v</ci>
+                                    <ci>EKshift</ci>
+                                    <cn cellml:units="millivolt">43.94</cn>
+                                </apply>
+                                <cn cellml:units="millivolt">5.711</cn>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>delta_epi</ci>
+                <piecewise>
+                    <piece>
+                        <apply>
+                            <minus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <divide/>
+                                <cn cellml:units="dimensionless">0.95</cn>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <exp/>
+                                        <apply>
+                                            <divide/>
+                                            <apply>
+                                                <plus/>
+                                                <ci>v</ci>
+                                                <ci>EKshift</ci>
+                                                <cn cellml:units="millivolt">70</cn>
+                                            </apply>
+                                            <cn cellml:units="millivolt">5</cn>
+                                        </apply>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">1</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <cn cellml:units="dimensionless">1</cn>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tiF_b</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="millisecond">4.562</cn>
+                    <apply>
+                        <divide/>
+                        <cn cellml:units="millisecond">1</cn>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.3933</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <minus/>
+                                            <apply>
+                                                <plus/>
+                                                <ci>v</ci>
+                                                <ci>EKshift</ci>
+                                                <cn cellml:units="millivolt">100</cn>
+                                            </apply>
+                                        </apply>
+                                        <cn cellml:units="millivolt">100</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.08004</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <ci>EKshift</ci>
+                                            <cn cellml:units="millivolt">50</cn>
+                                        </apply>
+                                        <cn cellml:units="millivolt">16.59</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tiS_b</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="millisecond">23.62</cn>
+                    <apply>
+                        <divide/>
+                        <cn cellml:units="millisecond">1</cn>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.001416</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <minus/>
+                                            <apply>
+                                                <plus/>
+                                                <ci>v</ci>
+                                                <ci>EKshift</ci>
+                                                <cn cellml:units="millivolt">96.52</cn>
+                                            </apply>
+                                        </apply>
+                                        <cn cellml:units="millivolt">59.05</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless" type="e-notation">1.78<sep/>-8</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <ci>EKshift</ci>
+                                            <cn cellml:units="millivolt">114.1</cn>
+                                        </apply>
+                                        <cn cellml:units="millivolt">8.079</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tiF</ci>
+                <apply>
+                    <times/>
+                    <ci>tiF_b</ci>
+                    <ci>delta_epi</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tiS</ci>
+                <apply>
+                    <times/>
+                    <ci>tiS_b</ci>
+                    <ci>delta_epi</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>AiF</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <minus/>
+                                    <apply>
+                                        <plus/>
+                                        <ci>v</ci>
+                                        <ci>EKshift</ci>
+                                    </apply>
+                                    <cn cellml:units="millivolt">213.6</cn>
+                                </apply>
+                                <cn cellml:units="millivolt">151.2</cn>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>AiS</ci>
+                <apply>
+                    <minus/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <ci>AiF</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>iF</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>iss</ci>
+                        <ci>iF</ci>
+                    </apply>
+                    <ci>tiF</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>iS</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>iss</ci>
+                        <ci>iS</ci>
+                    </apply>
+                    <ci>tiS</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>i</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>AiF</ci>
+                        <ci>iF</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>AiS</ci>
+                        <ci>iS</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>assp</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <minus/>
+                                    <apply>
+                                        <minus/>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <ci>EKshift</ci>
+                                        </apply>
+                                        <cn cellml:units="millivolt">24.34</cn>
+                                    </apply>
+                                </apply>
+                                <cn cellml:units="millivolt">14.82</cn>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>ap</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>assp</ci>
+                        <ci>ap</ci>
+                    </apply>
+                    <ci>ta</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>dti_develop</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="dimensionless">1.354</cn>
+                    <apply>
+                        <divide/>
+                        <cn cellml:units="dimensionless" type="e-notation">1<sep/>-4</cn>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <exp/>
+                                <apply>
+                                    <divide/>
+                                    <apply>
+                                        <minus/>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <ci>EKshift</ci>
+                                        </apply>
+                                        <cn cellml:units="millivolt">167.4</cn>
+                                    </apply>
+                                    <cn cellml:units="millivolt">15.89</cn>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <exp/>
+                                <apply>
+                                    <divide/>
+                                    <apply>
+                                        <minus/>
+                                        <apply>
+                                            <minus/>
+                                            <apply>
+                                                <plus/>
+                                                <ci>v</ci>
+                                                <ci>EKshift</ci>
+                                            </apply>
+                                            <cn cellml:units="millivolt">12.23</cn>
+                                        </apply>
+                                    </apply>
+                                    <cn cellml:units="millivolt">0.2154</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>dti_recover</ci>
+                <apply>
+                    <minus/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <divide/>
+                        <cn cellml:units="dimensionless">0.5</cn>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <exp/>
+                                <apply>
+                                    <divide/>
+                                    <apply>
+                                        <plus/>
+                                        <ci>v</ci>
+                                        <ci>EKshift</ci>
+                                        <cn cellml:units="millivolt">70.0</cn>
+                                    </apply>
+                                    <cn cellml:units="millivolt">20.0</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tiFp</ci>
+                <apply>
+                    <times/>
+                    <ci>dti_develop</ci>
+                    <ci>dti_recover</ci>
+                    <ci>tiF</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tiSp</ci>
+                <apply>
+                    <times/>
+                    <ci>dti_develop</ci>
+                    <ci>dti_recover</ci>
+                    <ci>tiS</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>iFp</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>iss</ci>
+                        <ci>iFp</ci>
+                    </apply>
+                    <ci>tiFp</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>iSp</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>iss</ci>
+                        <ci>iSp</ci>
+                    </apply>
+                    <ci>tiSp</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>ip</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>AiF</ci>
+                        <ci>iFp</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>AiS</ci>
+                        <ci>iSp</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Gto</ci>
+                <piecewise>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>Gto_b</ci>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">1</cn>
+                        </apply>
+                    </piece>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>Gto_b</ci>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <ci>Gto_b</ci>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>fItop</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <divide/>
+                            <ci>KmCaMK</ci>
+                            <ci>CaMKa</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Ito</ci>
+                <apply>
+                    <times/>
+                    <ci>Gto</ci>
+                    <apply>
+                        <minus/>
+                        <ci>v</ci>
+                        <ci>EK</ci>
+                    </apply>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>fItop</ci>
+                            </apply>
+                            <ci>a</ci>
+                            <ci>i</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>fItop</ci>
+                            <ci>ap</ci>
+                            <ci>ip</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="ICaL">
+        <variable initial_value="0.002" name="Kmn" units="millimolar"/>
+        <variable initial_value="500" name="k2n" units="per_millisecond"/>
+        <variable cmeta:id="membrane_L_type_calcium_current_conductance" initial_value="8.3757e-05" name="PCa_b" units="dimensionless"/>
+        <variable name="dss" units="dimensionless"/>
+        <variable initial_value="-8.334604e-30" name="d" units="dimensionless"/>
+        <variable name="fss" units="dimensionless"/>
+        <variable initial_value="0.6" name="Aff" units="dimensionless"/>
+        <variable name="Afs" units="dimensionless"/>
+        <variable initial_value="1.000000e+00" name="ff" units="dimensionless"/>
+        <variable initial_value="9.183587e-01" name="fs" units="dimensionless"/>
+        <variable name="f" units="dimensionless"/>
+        <variable name="fcass" units="dimensionless"/>
+        <variable name="jcass" units="dimensionless"/>
+        <variable name="Afcaf" units="dimensionless"/>
+        <variable name="Afcas" units="dimensionless"/>
+        <variable initial_value="1.000000e+00" name="fcaf" units="dimensionless"/>
+        <variable initial_value="9.997540e-01" name="fcas" units="dimensionless"/>
+        <variable name="fca" units="dimensionless"/>
+        <variable initial_value="9.999743e-01" name="jca" units="dimensionless"/>
+        <variable initial_value="1.000000e+00" name="ffp" units="dimensionless"/>
+        <variable name="fp" units="dimensionless"/>
+        <variable initial_value="1.000000e+00" name="fcafp" units="dimensionless"/>
+        <variable name="fcap" units="dimensionless"/>
+        <variable name="km2n" units="per_millisecond"/>
+        <variable name="anca_ss" units="dimensionless"/>
+        <variable initial_value="5.336520e-04" name="nca_ss" units="dimensionless"/>
+        <variable name="anca_i" units="dimensionless"/>
+        <variable initial_value="1.257861e-03" name="nca_i" units="dimensionless"/>
+        <variable name="PhiCaL_ss" units="dimensionless"/>
+        <variable name="PhiCaNa_ss" units="dimensionless"/>
+        <variable name="PhiCaK_ss" units="dimensionless"/>
+        <variable name="PhiCaL_i" units="dimensionless"/>
+        <variable name="PhiCaNa_i" units="dimensionless"/>
+        <variable name="PhiCaK_i" units="dimensionless"/>
+        <variable name="PCa" units="dimensionless"/>
+        <variable name="celltype" public_interface="in" units="dimensionless"/>
+        <variable name="PCap" units="dimensionless"/>
+        <variable name="PCaNa" units="dimensionless"/>
+        <variable name="PCaK" units="dimensionless"/>
+        <variable name="PCaNap" units="dimensionless"/>
+        <variable name="PCaKp" units="dimensionless"/>
+        <variable name="fICaLp" units="dimensionless"/>
+        <variable name="td" units="millisecond"/>
+        <variable name="tff" units="millisecond"/>
+        <variable name="tfs" units="millisecond"/>
+        <variable name="tfcaf" units="millisecond"/>
+        <variable name="tfcas" units="millisecond"/>
+        <variable initial_value="72.5" name="tjca" units="millisecond"/>
+        <variable name="tffp" units="millisecond"/>
+        <variable name="tfcafp" units="millisecond"/>
+        <variable name="ICaL_ss" public_interface="out" units="microA_per_microF"/>
+        <variable name="ICaNa_ss" public_interface="out" units="microA_per_microF"/>
+        <variable name="ICaK_ss" public_interface="out" units="microA_per_microF"/>
+        <variable name="ICaL_i" public_interface="out" units="microA_per_microF"/>
+        <variable name="ICaNa_i" public_interface="out" units="microA_per_microF"/>
+        <variable name="ICaK_i" public_interface="out" units="microA_per_microF"/>
+        <variable cmeta:id="membrane_L_type_calcium_current" name="ICaL" public_interface="out" units="microA_per_microF"/>
+        <variable name="ICaNa" public_interface="out" units="microA_per_microF"/>
+        <variable name="ICaK" public_interface="out" units="microA_per_microF"/>
+        <variable name="v" public_interface="in" units="millivolt"/>
+        <variable name="time" public_interface="in" units="millisecond"/>
+        <variable name="vffrt" public_interface="in" units="coulomb_per_mole"/>
+        <variable name="vfrt" public_interface="in" units="dimensionless"/>
+        <variable name="cao" public_interface="in" units="millimolar"/>
+        <variable name="cass" public_interface="in" units="millimolar"/>
+        <variable name="cai" public_interface="in" units="millimolar"/>
+        <variable name="nao" public_interface="in" units="millimolar"/>
+        <variable name="nass" public_interface="in" units="millimolar"/>
+        <variable name="nai" public_interface="in" units="millimolar"/>
+        <variable name="ko" public_interface="in" units="millimolar"/>
+        <variable name="kss" public_interface="in" units="millimolar"/>
+        <variable name="ki" public_interface="in" units="millimolar"/>
+        <variable name="clo" public_interface="in" units="millimolar"/>
+        <variable name="cli" public_interface="in" units="millimolar"/>
+        <variable name="clss" public_interface="in" units="millimolar"/>
+        <variable name="KmCaMK" public_interface="in" units="millimolar"/>
+        <variable name="CaMKa" public_interface="in" units="millimolar"/>
+        <variable name="T" public_interface="in" units="kelvin"/>
+        <variable initial_value="0" name="vShift" units="millivolt"/>
+        <variable initial_value="0" name="offset" units="millisecond"/>
+        <variable name="Io" units="dimensionless"/>
+        <variable name="Iss" units="dimensionless"/>
+        <variable name="Ii" units="dimensionless"/>
+        <variable initial_value="74" name="dielConstant" units="per_kelvin"/>
+        <variable name="constA" units="dimensionless"/>
+        <variable name="gamma_cao" public_interface="out" units="dimensionless"/>
+        <variable name="gamma_cass" units="dimensionless"/>
+        <variable name="gamma_cai" public_interface="out" units="dimensionless"/>
+        <variable name="gamma_nao" units="dimensionless"/>
+        <variable name="gamma_nass" units="dimensionless"/>
+        <variable name="gamma_nai" units="dimensionless"/>
+        <variable name="gamma_ko" units="dimensionless"/>
+        <variable name="gamma_kss" units="dimensionless"/>
+        <variable name="gamma_ki" units="dimensionless"/>
+        <variable initial_value="0.8" name="ICaL_fractionSS" units="dimensionless"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>dss</ci>
+                <piecewise>
+                    <piece>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <geq/>
+                            <ci>v</ci>
+                            <cn cellml:units="millivolt">31.4978</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <apply>
+                            <times/>
+                            <cn cellml:units="dimensionless">1.0763</cn>
+                            <apply>
+                                <exp/>
+                                <apply>
+                                    <times/>
+                                    <apply>
+                                        <minus/>
+                                        <cn cellml:units="dimensionless">1.0070</cn>
+                                    </apply>
+                                    <apply>
+                                        <exp/>
+                                        <apply>
+                                            <times/>
+                                            <apply>
+                                                <minus/>
+                                                <cn cellml:units="per_millivolt">0.0829</cn>
+                                            </apply>
+                                            <ci>v</ci>
+                                        </apply>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>td</ci>
+                <apply>
+                    <plus/>
+                    <ci>offset</ci>
+                    <cn cellml:units="millisecond">0.6</cn>
+                    <apply>
+                        <divide/>
+                        <cn cellml:units="millisecond">1</cn>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <exp/>
+                                <apply>
+                                    <times/>
+                                    <apply>
+                                        <minus/>
+                                        <cn cellml:units="per_millivolt">0.05</cn>
+                                    </apply>
+                                    <apply>
+                                        <plus/>
+                                        <ci>v</ci>
+                                        <ci>vShift</ci>
+                                        <cn cellml:units="millivolt">6</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <exp/>
+                                <apply>
+                                    <times/>
+                                    <cn cellml:units="per_millivolt">0.09</cn>
+                                    <apply>
+                                        <plus/>
+                                        <ci>v</ci>
+                                        <ci>vShift</ci>
+                                        <cn cellml:units="millivolt">14</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>d</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>dss</ci>
+                        <ci>d</ci>
+                    </apply>
+                    <ci>td</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>fss</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <plus/>
+                                    <ci>v</ci>
+                                    <cn cellml:units="millivolt">19.58</cn>
+                                </apply>
+                                <cn cellml:units="millivolt">3.696</cn>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tff</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="millisecond">7</cn>
+                    <apply>
+                        <divide/>
+                        <cn cellml:units="millisecond">1</cn>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.0045</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <minus/>
+                                            <apply>
+                                                <plus/>
+                                                <ci>v</ci>
+                                                <cn cellml:units="millivolt">20</cn>
+                                            </apply>
+                                        </apply>
+                                        <cn cellml:units="millivolt">10</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.0045</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <cn cellml:units="millivolt">20</cn>
+                                        </apply>
+                                        <cn cellml:units="millivolt">10</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tfs</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="millisecond">1000</cn>
+                    <apply>
+                        <divide/>
+                        <cn cellml:units="millisecond">1</cn>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.000035</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <minus/>
+                                            <apply>
+                                                <plus/>
+                                                <ci>v</ci>
+                                                <cn cellml:units="millivolt">5</cn>
+                                            </apply>
+                                        </apply>
+                                        <cn cellml:units="millivolt">4</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.000035</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <cn cellml:units="millivolt">5</cn>
+                                        </apply>
+                                        <cn cellml:units="millivolt">6</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Afs</ci>
+                <apply>
+                    <minus/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <ci>Aff</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>ff</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>fss</ci>
+                        <ci>ff</ci>
+                    </apply>
+                    <ci>tff</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>fs</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>fss</ci>
+                        <ci>fs</ci>
+                    </apply>
+                    <ci>tfs</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>f</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>Aff</ci>
+                        <ci>ff</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>Afs</ci>
+                        <ci>fs</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>fcass</ci>
+                <ci>fss</ci>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tfcaf</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="millisecond">7</cn>
+                    <apply>
+                        <divide/>
+                        <cn cellml:units="millisecond">1</cn>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.04</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <minus/>
+                                            <apply>
+                                                <minus/>
+                                                <ci>v</ci>
+                                                <cn cellml:units="millivolt">4</cn>
+                                            </apply>
+                                        </apply>
+                                        <cn cellml:units="millivolt">7</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.04</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <minus/>
+                                            <ci>v</ci>
+                                            <cn cellml:units="millivolt">4</cn>
+                                        </apply>
+                                        <cn cellml:units="millivolt">7</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tfcas</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="millisecond">100</cn>
+                    <apply>
+                        <divide/>
+                        <cn cellml:units="millisecond">1</cn>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.00012</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <minus/>
+                                            <ci>v</ci>
+                                        </apply>
+                                        <cn cellml:units="millivolt">3</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.00012</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <divide/>
+                                        <ci>v</ci>
+                                        <cn cellml:units="millivolt">7</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Afcaf</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="dimensionless">0.3</cn>
+                    <apply>
+                        <divide/>
+                        <cn cellml:units="dimensionless">0.6</cn>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <exp/>
+                                <apply>
+                                    <divide/>
+                                    <apply>
+                                        <minus/>
+                                        <ci>v</ci>
+                                        <cn cellml:units="millivolt">10</cn>
+                                    </apply>
+                                    <cn cellml:units="millivolt">10</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Afcas</ci>
+                <apply>
+                    <minus/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <ci>Afcaf</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>fcaf</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>fcass</ci>
+                        <ci>fcaf</ci>
+                    </apply>
+                    <ci>tfcaf</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>fcas</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>fcass</ci>
+                        <ci>fcas</ci>
+                    </apply>
+                    <ci>tfcas</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>fca</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>Afcaf</ci>
+                        <ci>fcaf</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>Afcas</ci>
+                        <ci>fcas</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>jcass</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1.0</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1.0</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <plus/>
+                                    <ci>v</ci>
+                                    <cn cellml:units="millivolt">18.08</cn>
+                                </apply>
+                                <cn cellml:units="millivolt">2.7916</cn>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>jca</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>jcass</ci>
+                        <ci>jca</ci>
+                    </apply>
+                    <ci>tjca</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tffp</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless">2.5</cn>
+                    <ci>tff</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>ffp</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>fss</ci>
+                        <ci>ffp</ci>
+                    </apply>
+                    <ci>tffp</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>fp</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>Aff</ci>
+                        <ci>ffp</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>Afs</ci>
+                        <ci>fs</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tfcafp</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless">2.5</cn>
+                    <ci>tfcaf</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>fcafp</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>fcass</ci>
+                        <ci>fcafp</ci>
+                    </apply>
+                    <ci>tfcafp</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>fcap</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>Afcaf</ci>
+                        <ci>fcafp</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>Afcas</ci>
+                        <ci>fcas</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>km2n</ci>
+                <apply>
+                    <times/>
+                    <ci>jca</ci>
+                    <cn cellml:units="per_millisecond">1</cn>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>anca_ss</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <divide/>
+                            <ci>k2n</ci>
+                            <ci>km2n</ci>
+                        </apply>
+                        <apply>
+                            <power/>
+                            <apply>
+                                <plus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <apply>
+                                    <divide/>
+                                    <ci>Kmn</ci>
+                                    <ci>cass</ci>
+                                </apply>
+                            </apply>
+                            <cn cellml:units="dimensionless">4</cn>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>nca_ss</ci>
+                </apply>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <times/>
+                        <ci>anca_ss</ci>
+                        <ci>k2n</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>nca_ss</ci>
+                        <ci>km2n</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Io</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">0.5</cn>
+                        <apply>
+                            <plus/>
+                            <ci>nao</ci>
+                            <ci>ko</ci>
+                            <ci>clo</ci>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">4</cn>
+                                <ci>cao</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                    <cn cellml:units="millimolar">1000</cn>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Iss</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">0.5</cn>
+                        <apply>
+                            <plus/>
+                            <ci>nass</ci>
+                            <ci>kss</ci>
+                            <ci>clss</ci>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">4</cn>
+                                <ci>cass</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                    <cn cellml:units="millimolar">1000</cn>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>constA</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless" type="e-notation">1.82<sep/>6</cn>
+                    <apply>
+                        <power/>
+                        <apply>
+                            <times/>
+                            <ci>dielConstant</ci>
+                            <ci>T</ci>
+                        </apply>
+                        <apply>
+                            <minus/>
+                            <cn cellml:units="dimensionless">1.5</cn>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>gamma_cass</ci>
+                <apply>
+                    <exp/>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <minus/>
+                            <ci>constA</ci>
+                        </apply>
+                        <cn cellml:units="dimensionless">4</cn>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <root/>
+                                    <ci>Iss</ci>
+                                </apply>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <root/>
+                                        <ci>Iss</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.3</cn>
+                                <ci>Iss</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>gamma_cao</ci>
+                <apply>
+                    <exp/>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <minus/>
+                            <ci>constA</ci>
+                        </apply>
+                        <cn cellml:units="dimensionless">4</cn>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <root/>
+                                    <ci>Io</ci>
+                                </apply>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <root/>
+                                        <ci>Io</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.3</cn>
+                                <ci>Io</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>gamma_nass</ci>
+                <apply>
+                    <exp/>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <minus/>
+                            <ci>constA</ci>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <root/>
+                                    <ci>Iss</ci>
+                                </apply>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <root/>
+                                        <ci>Iss</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.3</cn>
+                                <ci>Iss</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>gamma_nao</ci>
+                <apply>
+                    <exp/>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <minus/>
+                            <ci>constA</ci>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <root/>
+                                    <ci>Io</ci>
+                                </apply>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <root/>
+                                        <ci>Io</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.3</cn>
+                                <ci>Io</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>gamma_kss</ci>
+                <apply>
+                    <exp/>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <minus/>
+                            <ci>constA</ci>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <root/>
+                                    <ci>Iss</ci>
+                                </apply>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <root/>
+                                        <ci>Iss</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.3</cn>
+                                <ci>Iss</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>gamma_ko</ci>
+                <apply>
+                    <exp/>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <minus/>
+                            <ci>constA</ci>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <root/>
+                                    <ci>Io</ci>
+                                </apply>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <root/>
+                                        <ci>Io</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.3</cn>
+                                <ci>Io</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>PhiCaL_ss</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">4</cn>
+                        <ci>vffrt</ci>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <times/>
+                                <ci>gamma_cass</ci>
+                                <ci>cass</ci>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <times/>
+                                        <cn cellml:units="dimensionless">2</cn>
+                                        <ci>vfrt</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <ci>gamma_cao</ci>
+                                <ci>cao</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">2</cn>
+                                <ci>vfrt</ci>
+                            </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>PhiCaNa_ss</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <ci>vffrt</ci>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <times/>
+                                <ci>gamma_nass</ci>
+                                <ci>nass</ci>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <times/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>vfrt</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <ci>gamma_nao</ci>
+                                <ci>nao</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>vfrt</ci>
+                            </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>PhiCaK_ss</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <ci>vffrt</ci>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <times/>
+                                <ci>gamma_kss</ci>
+                                <ci>kss</ci>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <times/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>vfrt</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <ci>gamma_ko</ci>
+                                <ci>ko</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>vfrt</ci>
+                            </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>PCa</ci>
+                <piecewise>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>PCa_b</ci>
+                            <cn cellml:units="dimensionless">1.2</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">1</cn>
+                        </apply>
+                    </piece>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>PCa_b</ci>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <ci>PCa_b</ci>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>PCap</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless">1.1</cn>
+                    <ci>PCa</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>PCaNa</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless">0.00125</cn>
+                    <ci>PCa</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>PCaK</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless" type="e-notation">3.574<sep/>-4</cn>
+                    <ci>PCa</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>PCaNap</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless">0.00125</cn>
+                    <ci>PCap</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>PCaKp</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless" type="e-notation">3.574<sep/>-4</cn>
+                    <ci>PCap</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>fICaLp</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <divide/>
+                            <ci>KmCaMK</ci>
+                            <ci>CaMKa</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>ICaL_ss</ci>
+                <apply>
+                    <times/>
+                    <ci>ICaL_fractionSS</ci>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>fICaLp</ci>
+                            </apply>
+                            <ci>PCa</ci>
+                            <ci>PhiCaL_ss</ci>
+                            <ci>d</ci>
+                            <apply>
+                                <plus/>
+                                <apply>
+                                    <times/>
+                                    <ci>f</ci>
+                                    <apply>
+                                        <minus/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>nca_ss</ci>
+                                    </apply>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <ci>jca</ci>
+                                    <ci>fca</ci>
+                                    <ci>nca_ss</ci>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>fICaLp</ci>
+                            <ci>PCap</ci>
+                            <ci>PhiCaL_ss</ci>
+                            <ci>d</ci>
+                            <apply>
+                                <plus/>
+                                <apply>
+                                    <times/>
+                                    <ci>fp</ci>
+                                    <apply>
+                                        <minus/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>nca_ss</ci>
+                                    </apply>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <ci>jca</ci>
+                                    <ci>fcap</ci>
+                                    <ci>nca_ss</ci>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>ICaNa_ss</ci>
+                <apply>
+                    <times/>
+                    <ci>ICaL_fractionSS</ci>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>fICaLp</ci>
+                            </apply>
+                            <ci>PCaNa</ci>
+                            <ci>PhiCaNa_ss</ci>
+                            <ci>d</ci>
+                            <apply>
+                                <plus/>
+                                <apply>
+                                    <times/>
+                                    <ci>f</ci>
+                                    <apply>
+                                        <minus/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>nca_ss</ci>
+                                    </apply>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <ci>jca</ci>
+                                    <ci>fca</ci>
+                                    <ci>nca_ss</ci>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>fICaLp</ci>
+                            <ci>PCaNap</ci>
+                            <ci>PhiCaNa_ss</ci>
+                            <ci>d</ci>
+                            <apply>
+                                <plus/>
+                                <apply>
+                                    <times/>
+                                    <ci>fp</ci>
+                                    <apply>
+                                        <minus/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>nca_ss</ci>
+                                    </apply>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <ci>jca</ci>
+                                    <ci>fcap</ci>
+                                    <ci>nca_ss</ci>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>ICaK_ss</ci>
+                <apply>
+                    <times/>
+                    <ci>ICaL_fractionSS</ci>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>fICaLp</ci>
+                            </apply>
+                            <ci>PCaK</ci>
+                            <ci>PhiCaK_ss</ci>
+                            <ci>d</ci>
+                            <apply>
+                                <plus/>
+                                <apply>
+                                    <times/>
+                                    <ci>f</ci>
+                                    <apply>
+                                        <minus/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>nca_ss</ci>
+                                    </apply>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <ci>jca</ci>
+                                    <ci>fca</ci>
+                                    <ci>nca_ss</ci>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>fICaLp</ci>
+                            <ci>PCaKp</ci>
+                            <ci>PhiCaK_ss</ci>
+                            <ci>d</ci>
+                            <apply>
+                                <plus/>
+                                <apply>
+                                    <times/>
+                                    <ci>fp</ci>
+                                    <apply>
+                                        <minus/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>nca_ss</ci>
+                                    </apply>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <ci>jca</ci>
+                                    <ci>fcap</ci>
+                                    <ci>nca_ss</ci>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>anca_i</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <divide/>
+                            <ci>k2n</ci>
+                            <ci>km2n</ci>
+                        </apply>
+                        <apply>
+                            <power/>
+                            <apply>
+                                <plus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <apply>
+                                    <divide/>
+                                    <ci>Kmn</ci>
+                                    <ci>cai</ci>
+                                </apply>
+                            </apply>
+                            <cn cellml:units="dimensionless">4</cn>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>nca_i</ci>
+                </apply>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <times/>
+                        <ci>anca_i</ci>
+                        <ci>k2n</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>nca_i</ci>
+                        <ci>km2n</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Ii</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">0.5</cn>
+                        <apply>
+                            <plus/>
+                            <ci>nai</ci>
+                            <ci>ki</ci>
+                            <ci>cli</ci>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">4</cn>
+                                <ci>cai</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                    <cn cellml:units="millimolar">1000</cn>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>gamma_cai</ci>
+                <apply>
+                    <exp/>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <minus/>
+                            <ci>constA</ci>
+                        </apply>
+                        <cn cellml:units="dimensionless">4</cn>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <root/>
+                                    <ci>Ii</ci>
+                                </apply>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <root/>
+                                        <ci>Ii</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.3</cn>
+                                <ci>Ii</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>gamma_nai</ci>
+                <apply>
+                    <exp/>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <minus/>
+                            <ci>constA</ci>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <root/>
+                                    <ci>Ii</ci>
+                                </apply>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <root/>
+                                        <ci>Ii</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.3</cn>
+                                <ci>Ii</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>gamma_ki</ci>
+                <apply>
+                    <exp/>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <minus/>
+                            <ci>constA</ci>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <root/>
+                                    <ci>Ii</ci>
+                                </apply>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <root/>
+                                        <ci>Ii</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.3</cn>
+                                <ci>Ii</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>PhiCaL_i</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">4</cn>
+                        <ci>vffrt</ci>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <times/>
+                                <ci>gamma_cai</ci>
+                                <ci>cai</ci>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <times/>
+                                        <cn cellml:units="dimensionless">2</cn>
+                                        <ci>vfrt</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <ci>gamma_cao</ci>
+                                <ci>cao</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">2</cn>
+                                <ci>vfrt</ci>
+                            </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>PhiCaNa_i</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <ci>vffrt</ci>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <times/>
+                                <ci>gamma_nai</ci>
+                                <ci>nai</ci>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <times/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>vfrt</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <ci>gamma_nao</ci>
+                                <ci>nao</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>vfrt</ci>
+                            </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>PhiCaK_i</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <ci>vffrt</ci>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <times/>
+                                <ci>gamma_ki</ci>
+                                <ci>ki</ci>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <times/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>vfrt</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <ci>gamma_ko</ci>
+                                <ci>ko</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>vfrt</ci>
+                            </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>ICaL_i</ci>
+                <apply>
+                    <times/>
+                    <apply>
+                        <minus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <ci>ICaL_fractionSS</ci>
+                    </apply>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>fICaLp</ci>
+                            </apply>
+                            <ci>PCa</ci>
+                            <ci>PhiCaL_i</ci>
+                            <ci>d</ci>
+                            <apply>
+                                <plus/>
+                                <apply>
+                                    <times/>
+                                    <ci>f</ci>
+                                    <apply>
+                                        <minus/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>nca_i</ci>
+                                    </apply>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <ci>jca</ci>
+                                    <ci>fca</ci>
+                                    <ci>nca_i</ci>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>fICaLp</ci>
+                            <ci>PCap</ci>
+                            <ci>PhiCaL_i</ci>
+                            <ci>d</ci>
+                            <apply>
+                                <plus/>
+                                <apply>
+                                    <times/>
+                                    <ci>fp</ci>
+                                    <apply>
+                                        <minus/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>nca_i</ci>
+                                    </apply>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <ci>jca</ci>
+                                    <ci>fcap</ci>
+                                    <ci>nca_i</ci>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>ICaNa_i</ci>
+                <apply>
+                    <times/>
+                    <apply>
+                        <minus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <ci>ICaL_fractionSS</ci>
+                    </apply>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>fICaLp</ci>
+                            </apply>
+                            <ci>PCaNa</ci>
+                            <ci>PhiCaNa_i</ci>
+                            <ci>d</ci>
+                            <apply>
+                                <plus/>
+                                <apply>
+                                    <times/>
+                                    <ci>f</ci>
+                                    <apply>
+                                        <minus/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>nca_i</ci>
+                                    </apply>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <ci>jca</ci>
+                                    <ci>fca</ci>
+                                    <ci>nca_i</ci>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>fICaLp</ci>
+                            <ci>PCaNap</ci>
+                            <ci>PhiCaNa_i</ci>
+                            <ci>d</ci>
+                            <apply>
+                                <plus/>
+                                <apply>
+                                    <times/>
+                                    <ci>fp</ci>
+                                    <apply>
+                                        <minus/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>nca_i</ci>
+                                    </apply>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <ci>jca</ci>
+                                    <ci>fcap</ci>
+                                    <ci>nca_i</ci>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>ICaK_i</ci>
+                <apply>
+                    <times/>
+                    <apply>
+                        <minus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <ci>ICaL_fractionSS</ci>
+                    </apply>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>fICaLp</ci>
+                            </apply>
+                            <ci>PCaK</ci>
+                            <ci>PhiCaK_i</ci>
+                            <ci>d</ci>
+                            <apply>
+                                <plus/>
+                                <apply>
+                                    <times/>
+                                    <ci>f</ci>
+                                    <apply>
+                                        <minus/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>nca_i</ci>
+                                    </apply>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <ci>jca</ci>
+                                    <ci>fca</ci>
+                                    <ci>nca_i</ci>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>fICaLp</ci>
+                            <ci>PCaKp</ci>
+                            <ci>PhiCaK_i</ci>
+                            <ci>d</ci>
+                            <apply>
+                                <plus/>
+                                <apply>
+                                    <times/>
+                                    <ci>fp</ci>
+                                    <apply>
+                                        <minus/>
+                                        <cn cellml:units="dimensionless">1</cn>
+                                        <ci>nca_i</ci>
+                                    </apply>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <ci>jca</ci>
+                                    <ci>fcap</ci>
+                                    <ci>nca_i</ci>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>ICaL</ci>
+                <apply>
+                    <plus/>
+                    <ci>ICaL_ss</ci>
+                    <ci>ICaL_i</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>ICaNa</ci>
+                <apply>
+                    <plus/>
+                    <ci>ICaNa_ss</ci>
+                    <ci>ICaNa_i</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>ICaK</ci>
+                <apply>
+                    <plus/>
+                    <ci>ICaK_ss</ci>
+                    <ci>ICaK_i</ci>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="IKr">
+        <variable cmeta:id="membrane_rapid_delayed_rectifier_potassium_current_conductance" initial_value="0.0321" name="GKr_b" units="milliS_per_microF"/>
+        <variable initial_value="9.983451e-01" name="C1" units="dimensionless"/>
+        <variable initial_value="7.086460e-04" name="C2" units="dimensionless"/>
+        <variable initial_value="5.910047e-04" name="C3" units="dimensionless"/>
+        <variable initial_value="1.064230e-05" name="I" units="dimensionless"/>
+        <variable initial_value="3.445733e-04" name="O" units="dimensionless"/>
+        <variable name="alpha" units="per_millisecond"/>
+        <variable name="beta" units="per_millisecond"/>
+        <variable initial_value="0.154375" name="alpha_1" units="per_millisecond"/>
+        <variable initial_value="0.1911" name="beta_1" units="per_millisecond"/>
+        <variable name="alpha_2" units="per_millisecond"/>
+        <variable name="beta_2" units="per_millisecond"/>
+        <variable name="alpha_i" units="per_millisecond"/>
+        <variable name="beta_i" units="per_millisecond"/>
+        <variable name="alpha_C2ToI" units="per_millisecond"/>
+        <variable name="beta_ItoC2" units="per_millisecond"/>
+        <variable name="v" public_interface="in" units="millivolt"/>
+        <variable name="vfrt" public_interface="in" units="dimensionless"/>
+        <variable name="time" public_interface="in" units="millisecond"/>
+        <variable name="celltype" public_interface="in" units="dimensionless"/>
+        <variable name="GKr" units="milliS_per_microF"/>
+        <variable name="EK" public_interface="in" units="millivolt"/>
+        <variable name="ko" public_interface="in" units="millimolar"/>
+        <variable cmeta:id="membrane_rapid_delayed_rectifier_potassium_current" name="IKr" public_interface="out" units="microA_per_microF"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>alpha</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="per_millisecond">0.1161</cn>
+                    <apply>
+                        <exp/>
+                        <apply>
+                            <times/>
+                            <cn cellml:units="dimensionless">0.2990</cn>
+                            <ci>vfrt</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>beta</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="per_millisecond">0.2442</cn>
+                    <apply>
+                        <exp/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="dimensionless">1.604</cn>
+                            </apply>
+                            <ci>vfrt</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>alpha_2</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="per_millisecond">0.0578</cn>
+                    <apply>
+                        <exp/>
+                        <apply>
+                            <times/>
+                            <cn cellml:units="dimensionless">0.9710</cn>
+                            <ci>vfrt</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>beta_2</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="per_millisecond" type="e-notation">0.349<sep/>-3</cn>
+                    <apply>
+                        <exp/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="dimensionless">1.062</cn>
+                            </apply>
+                            <ci>vfrt</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>alpha_i</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="per_millisecond">0.2533</cn>
+                    <apply>
+                        <exp/>
+                        <apply>
+                            <times/>
+                            <cn cellml:units="dimensionless">0.5953</cn>
+                            <ci>vfrt</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>beta_i</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="per_millisecond">0.06525</cn>
+                    <apply>
+                        <exp/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="dimensionless">0.8209</cn>
+                            </apply>
+                            <ci>vfrt</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>alpha_C2ToI</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="per_millisecond" type="e-notation">0.52<sep/>-4</cn>
+                    <apply>
+                        <exp/>
+                        <apply>
+                            <times/>
+                            <cn cellml:units="dimensionless">1.525</cn>
+                            <ci>vfrt</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>beta_ItoC2</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>beta_2</ci>
+                        <ci>beta_i</ci>
+                        <ci>alpha_C2ToI</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>alpha_2</ci>
+                        <ci>alpha_i</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>C3</ci>
+                </apply>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <times/>
+                        <ci>beta</ci>
+                        <ci>C2</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>alpha</ci>
+                        <ci>C3</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>C2</ci>
+                </apply>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <ci>alpha</ci>
+                            <ci>C3</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>beta_1</ci>
+                            <ci>C1</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <plus/>
+                            <ci>beta</ci>
+                            <ci>alpha_1</ci>
+                        </apply>
+                        <ci>C2</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>C1</ci>
+                </apply>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <ci>alpha_1</ci>
+                            <ci>C2</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>beta_2</ci>
+                            <ci>O</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>beta_ItoC2</ci>
+                            <ci>I</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <plus/>
+                            <ci>beta_1</ci>
+                            <ci>alpha_2</ci>
+                            <ci>alpha_C2ToI</ci>
+                        </apply>
+                        <ci>C1</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>O</ci>
+                </apply>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <ci>alpha_2</ci>
+                            <ci>C1</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>beta_i</ci>
+                            <ci>I</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <plus/>
+                            <ci>beta_2</ci>
+                            <ci>alpha_i</ci>
+                        </apply>
+                        <ci>O</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>I</ci>
+                </apply>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <ci>alpha_C2ToI</ci>
+                            <ci>C1</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>alpha_i</ci>
+                            <ci>O</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <plus/>
+                            <ci>beta_ItoC2</ci>
+                            <ci>beta_i</ci>
+                        </apply>
+                        <ci>I</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>GKr</ci>
+                <piecewise>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>GKr_b</ci>
+                            <cn cellml:units="dimensionless">1.3</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">1</cn>
+                        </apply>
+                    </piece>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>GKr_b</ci>
+                            <cn cellml:units="dimensionless">0.8</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <ci>GKr_b</ci>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>IKr</ci>
+                <apply>
+                    <times/>
+                    <ci>GKr</ci>
+                    <apply>
+                        <root/>
+                        <apply>
+                            <divide/>
+                            <ci>ko</ci>
+                            <cn cellml:units="millimolar">5</cn>
+                        </apply>
+                    </apply>
+                    <ci>O</ci>
+                    <apply>
+                        <minus/>
+                        <ci>v</ci>
+                        <ci>EK</ci>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="IKs">
+        <variable cmeta:id="membrane_slow_delayed_rectifier_potassium_current_conductance" initial_value="0.0011" name="GKs_b" units="milliS_per_microF"/>
+        <variable name="GKs" units="milliS_per_microF"/>
+        <variable name="xs1ss" units="dimensionless"/>
+        <variable name="xs2ss" units="dimensionless"/>
+        <variable name="txs1" units="millisecond"/>
+        <variable initial_value="2.642293e-01" name="xs1" units="dimensionless"/>
+        <variable initial_value="1.327348e-04" name="xs2" units="dimensionless"/>
+        <variable name="KsCa" units="dimensionless"/>
+        <variable name="v" public_interface="in" units="millivolt"/>
+        <variable name="time" public_interface="in" units="millisecond"/>
+        <variable name="celltype" public_interface="in" units="dimensionless"/>
+        <variable name="EKs" public_interface="in" units="millivolt"/>
+        <variable cmeta:id="membrane_slow_delayed_rectifier_potassium_current" name="IKs" public_interface="out" units="microA_per_microF"/>
+        <variable name="txs2" units="millisecond"/>
+        <variable name="cai" public_interface="in" units="millimolar"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>xs1ss</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <minus/>
+                                    <apply>
+                                        <plus/>
+                                        <ci>v</ci>
+                                        <cn cellml:units="millivolt">11.6</cn>
+                                    </apply>
+                                </apply>
+                                <cn cellml:units="millivolt">8.932</cn>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>txs1</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="millisecond">817.3</cn>
+                    <apply>
+                        <divide/>
+                        <cn cellml:units="millisecond">1</cn>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless" type="e-notation">2.326<sep/>-4</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <cn cellml:units="millivolt">48.28</cn>
+                                        </apply>
+                                        <cn cellml:units="millivolt">17.8</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">0.001292</cn>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <divide/>
+                                        <apply>
+                                            <minus/>
+                                            <apply>
+                                                <plus/>
+                                                <ci>v</ci>
+                                                <cn cellml:units="millivolt">210</cn>
+                                            </apply>
+                                        </apply>
+                                        <cn cellml:units="millivolt">230</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>xs1</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>xs1ss</ci>
+                        <ci>xs1</ci>
+                    </apply>
+                    <ci>txs1</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>xs2ss</ci>
+                <ci>xs1ss</ci>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>txs2</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="millisecond">1</cn>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <cn cellml:units="dimensionless">0.01</cn>
+                            <apply>
+                                <exp/>
+                                <apply>
+                                    <divide/>
+                                    <apply>
+                                        <minus/>
+                                        <ci>v</ci>
+                                        <cn cellml:units="millivolt">50</cn>
+                                    </apply>
+                                    <cn cellml:units="millivolt">20</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <cn cellml:units="dimensionless">0.0193</cn>
+                            <apply>
+                                <exp/>
+                                <apply>
+                                    <divide/>
+                                    <apply>
+                                        <minus/>
+                                        <apply>
+                                            <plus/>
+                                            <ci>v</ci>
+                                            <cn cellml:units="millivolt">66.54</cn>
+                                        </apply>
+                                    </apply>
+                                    <cn cellml:units="millivolt">31</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>xs2</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>xs2ss</ci>
+                        <ci>xs2</ci>
+                    </apply>
+                    <ci>txs2</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>KsCa</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <divide/>
+                        <cn cellml:units="dimensionless">0.6</cn>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <power/>
+                                <apply>
+                                    <divide/>
+                                    <cn cellml:units="millimolar" type="e-notation">3.8<sep/>-5</cn>
+                                    <ci>cai</ci>
+                                </apply>
+                                <cn cellml:units="dimensionless">1.4</cn>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>GKs</ci>
+                <piecewise>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>GKs_b</ci>
+                            <cn cellml:units="dimensionless">1.4</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">1</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <ci>GKs_b</ci>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>IKs</ci>
+                <apply>
+                    <times/>
+                    <ci>GKs</ci>
+                    <ci>KsCa</ci>
+                    <ci>xs1</ci>
+                    <ci>xs2</ci>
+                    <apply>
+                        <minus/>
+                        <ci>v</ci>
+                        <ci>EKs</ci>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="IK1">
+        <variable name="GK1" units="milliS_per_microF"/>
+        <variable cmeta:id="membrane_inward_rectifier_potassium_current_conductance" initial_value="0.6992" name="GK1_b" units="milliS_per_microF"/>
+        <variable name="aK1" units="dimensionless"/>
+        <variable name="bK1" units="dimensionless"/>
+        <variable name="K1ss" units="dimensionless"/>
+        <variable name="v" public_interface="in" units="millivolt"/>
+        <variable name="celltype" public_interface="in" units="dimensionless"/>
+        <variable name="EK" public_interface="in" units="millivolt"/>
+        <variable name="ko" public_interface="in" units="millimolar"/>
+        <variable cmeta:id="membrane_inward_rectifier_potassium_current" name="IK1" public_interface="out" units="microA_per_microF"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>aK1</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">4.094</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="per_millivolt">0.1217</cn>
+                                <apply>
+                                    <minus/>
+                                    <apply>
+                                        <minus/>
+                                        <ci>v</ci>
+                                        <ci>EK</ci>
+                                    </apply>
+                                    <cn cellml:units="millivolt">49.934</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>bK1</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <cn cellml:units="dimensionless">15.72</cn>
+                            <apply>
+                                <exp/>
+                                <apply>
+                                    <times/>
+                                    <cn cellml:units="per_millivolt">0.0674</cn>
+                                    <apply>
+                                        <minus/>
+                                        <apply>
+                                            <minus/>
+                                            <ci>v</ci>
+                                            <ci>EK</ci>
+                                        </apply>
+                                        <cn cellml:units="millivolt">3.257</cn>
+                                    </apply>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="per_millivolt">0.0618</cn>
+                                <apply>
+                                    <minus/>
+                                    <apply>
+                                        <minus/>
+                                        <ci>v</ci>
+                                        <ci>EK</ci>
+                                    </apply>
+                                    <cn cellml:units="millivolt">594.31</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <times/>
+                                <apply>
+                                    <minus/>
+                                    <cn cellml:units="per_millivolt">0.1629</cn>
+                                </apply>
+                                <apply>
+                                    <plus/>
+                                    <apply>
+                                        <minus/>
+                                        <ci>v</ci>
+                                        <ci>EK</ci>
+                                    </apply>
+                                    <cn cellml:units="millivolt">14.207</cn>
+                                </apply>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>K1ss</ci>
+                <apply>
+                    <divide/>
+                    <ci>aK1</ci>
+                    <apply>
+                        <plus/>
+                        <ci>aK1</ci>
+                        <ci>bK1</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>GK1</ci>
+                <piecewise>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>GK1_b</ci>
+                            <cn cellml:units="dimensionless">1.2</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">1</cn>
+                        </apply>
+                    </piece>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>GK1_b</ci>
+                            <cn cellml:units="dimensionless">1.3</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <ci>GK1_b</ci>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>IK1</ci>
+                <apply>
+                    <times/>
+                    <ci>GK1</ci>
+                    <apply>
+                        <root/>
+                        <apply>
+                            <divide/>
+                            <ci>ko</ci>
+                            <cn cellml:units="millimolar">5</cn>
+                        </apply>
+                    </apply>
+                    <ci>K1ss</ci>
+                    <apply>
+                        <minus/>
+                        <ci>v</ci>
+                        <ci>EK</ci>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="INaCa">
+        <variable initial_value="0.35" name="INaCa_fractionSS" units="dimensionless"/>
+        <variable initial_value="15" name="kna1" units="per_millisecond"/>
+        <variable initial_value="5" name="kna2" units="per_millisecond"/>
+        <variable initial_value="88.12" name="kna3" units="per_millisecond"/>
+        <variable initial_value="12.5" name="kasymm" units="dimensionless"/>
+        <variable initial_value="6e4" name="wna" units="dimensionless"/>
+        <variable initial_value="6e4" name="wca" units="dimensionless"/>
+        <variable initial_value="5e3" name="wnaca" units="dimensionless"/>
+        <variable initial_value="1.5e6" name="kcaon" units="per_millisecond"/>
+        <variable initial_value="5e3" name="kcaoff" units="per_millisecond"/>
+        <variable initial_value="0.5224" name="qna" units="dimensionless"/>
+        <variable initial_value="0.167" name="qca" units="dimensionless"/>
+        <variable name="hna" units="dimensionless"/>
+        <variable name="hca" units="dimensionless"/>
+        <variable name="zca" public_interface="in" units="dimensionless"/>
+        <variable initial_value="150e-6" name="KmCaAct" units="millimolar"/>
+        <variable name="zna" public_interface="in" units="dimensionless"/>
+        <variable cmeta:id="membrane_sodium_calcium_exchanger_current_conductance" initial_value="0.0034" name="Gncx_b" units="milliS_per_microF"/>
+        <variable name="Gncx" units="milliS_per_microF"/>
+        <variable name="v" public_interface="in" units="millivolt"/>
+        <variable name="vfrt" public_interface="in" units="dimensionless"/>
+        <variable name="nai" public_interface="in" units="millimolar"/>
+        <variable name="nass" public_interface="in" units="millimolar"/>
+        <variable name="cass" public_interface="in" units="millimolar"/>
+        <variable name="nao" public_interface="in" units="millimolar"/>
+        <variable name="cai" public_interface="in" units="millimolar"/>
+        <variable name="cao" public_interface="in" units="millimolar"/>
+        <variable name="h1_i" units="dimensionless"/>
+        <variable name="h2_i" units="dimensionless"/>
+        <variable name="h3_i" units="dimensionless"/>
+        <variable name="h4_i" units="dimensionless"/>
+        <variable name="h5_i" units="dimensionless"/>
+        <variable name="h6_i" units="dimensionless"/>
+        <variable name="h7_i" units="dimensionless"/>
+        <variable name="h8_i" units="dimensionless"/>
+        <variable name="h9_i" units="dimensionless"/>
+        <variable name="h10_i" units="dimensionless"/>
+        <variable name="h11_i" units="dimensionless"/>
+        <variable name="h12_i" units="dimensionless"/>
+        <variable name="k1_i" units="dimensionless"/>
+        <variable name="k2_i" units="dimensionless"/>
+        <variable name="k3p_i" units="dimensionless"/>
+        <variable name="k3pp_i" units="dimensionless"/>
+        <variable name="k3_i" units="dimensionless"/>
+        <variable name="k4_i" units="dimensionless"/>
+        <variable name="k4p_i" units="dimensionless"/>
+        <variable name="k4pp_i" units="dimensionless"/>
+        <variable name="k5_i" units="dimensionless"/>
+        <variable name="k6_i" units="dimensionless"/>
+        <variable name="k7_i" units="dimensionless"/>
+        <variable name="k8_i" units="dimensionless"/>
+        <variable name="x1_i" units="dimensionless"/>
+        <variable name="x2_i" units="dimensionless"/>
+        <variable name="x3_i" units="dimensionless"/>
+        <variable name="x4_i" units="dimensionless"/>
+        <variable name="E1_i" units="dimensionless"/>
+        <variable name="E2_i" units="dimensionless"/>
+        <variable name="E3_i" units="dimensionless"/>
+        <variable name="E4_i" units="dimensionless"/>
+        <variable name="allo_i" units="dimensionless"/>
+        <variable name="JncxNa_i" units="millimolar_per_millisecond"/>
+        <variable name="JncxCa_i" units="millimolar_per_millisecond"/>
+        <variable name="celltype" public_interface="in" units="dimensionless"/>
+        <!--
+<variable cmeta:id="membrane_sodium_calcium_exchanger_current_i" name="INaCa_i" public_interface="out" units="microA_per_microF"/>
+<variable cmeta:id="membrane_sodium_calcium_exchanger_current_ss" name="INaCa_ss" public_interface="out" units="microA_per_microF"/>
+-->
+        <variable name="INaCa_i" public_interface="out" units="microA_per_microF"/>
+        <variable name="INaCa_ss" public_interface="out" units="microA_per_microF"/>
+        <variable name="h1_ss" units="dimensionless"/>
+        <variable name="h2_ss" units="dimensionless"/>
+        <variable name="h3_ss" units="dimensionless"/>
+        <variable name="h4_ss" units="dimensionless"/>
+        <variable name="h5_ss" units="dimensionless"/>
+        <variable name="h6_ss" units="dimensionless"/>
+        <variable name="h7_ss" units="dimensionless"/>
+        <variable name="h8_ss" units="dimensionless"/>
+        <variable name="h9_ss" units="dimensionless"/>
+        <variable name="h10_ss" units="dimensionless"/>
+        <variable name="h11_ss" units="dimensionless"/>
+        <variable name="h12_ss" units="dimensionless"/>
+        <variable name="k1_ss" units="dimensionless"/>
+        <variable name="k2_ss" units="dimensionless"/>
+        <variable name="k3p_ss" units="dimensionless"/>
+        <variable name="k3pp_ss" units="dimensionless"/>
+        <variable name="k3_ss" units="dimensionless"/>
+        <variable name="k4_ss" units="dimensionless"/>
+        <variable name="k4p_ss" units="dimensionless"/>
+        <variable name="k4pp_ss" units="dimensionless"/>
+        <variable name="k5_ss" units="dimensionless"/>
+        <variable name="k6_ss" units="dimensionless"/>
+        <variable name="k7_ss" units="dimensionless"/>
+        <variable name="k8_ss" units="dimensionless"/>
+        <variable name="x1_ss" units="dimensionless"/>
+        <variable name="x2_ss" units="dimensionless"/>
+        <variable name="x3_ss" units="dimensionless"/>
+        <variable name="x4_ss" units="dimensionless"/>
+        <variable name="E1_ss" units="dimensionless"/>
+        <variable name="E2_ss" units="dimensionless"/>
+        <variable name="E3_ss" units="dimensionless"/>
+        <variable name="E4_ss" units="dimensionless"/>
+        <variable name="allo_ss" units="dimensionless"/>
+        <variable name="JncxNa_ss" units="millimolar_per_millisecond"/>
+        <variable name="JncxCa_ss" units="millimolar_per_millisecond"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>hca</ci>
+                <apply>
+                    <exp/>
+                    <apply>
+                        <times/>
+                        <ci>qca</ci>
+                        <ci>vfrt</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>hna</ci>
+                <apply>
+                    <exp/>
+                    <apply>
+                        <times/>
+                        <ci>qna</ci>
+                        <ci>vfrt</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h1_i</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <divide/>
+                            <ci>nai</ci>
+                            <ci>kna3</ci>
+                        </apply>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <ci>hna</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h2_i</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>nai</ci>
+                        <ci>hna</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>kna3</ci>
+                        <ci>h1_i</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h3_i</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <ci>h1_i</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h4_i</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <divide/>
+                            <ci>nai</ci>
+                            <ci>kna1</ci>
+                        </apply>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <divide/>
+                                <ci>nai</ci>
+                                <ci>kna2</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h5_i</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>nai</ci>
+                        <ci>nai</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>h4_i</ci>
+                        <ci>kna1</ci>
+                        <ci>kna2</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h6_i</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <ci>h4_i</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h7_i</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <divide/>
+                            <ci>nao</ci>
+                            <ci>kna3</ci>
+                        </apply>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <divide/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>hna</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h8_i</ci>
+                <apply>
+                    <divide/>
+                    <ci>nao</ci>
+                    <apply>
+                        <times/>
+                        <ci>kna3</ci>
+                        <ci>hna</ci>
+                        <ci>h7_i</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h9_i</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <ci>h7_i</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h10_i</ci>
+                <apply>
+                    <plus/>
+                    <ci>kasymm</ci>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <divide/>
+                            <ci>nao</ci>
+                            <ci>kna1</ci>
+                        </apply>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <divide/>
+                                <ci>nao</ci>
+                                <ci>kna2</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h11_i</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>nao</ci>
+                        <ci>nao</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>h10_i</ci>
+                        <ci>kna1</ci>
+                        <ci>kna2</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h12_i</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <ci>h10_i</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k1_i</ci>
+                <apply>
+                    <times/>
+                    <ci>h12_i</ci>
+                    <ci>cao</ci>
+                    <ci>kcaon</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k2_i</ci>
+                <ci>kcaoff</ci>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k3p_i</ci>
+                <apply>
+                    <times/>
+                    <ci>h9_i</ci>
+                    <ci>wca</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k3pp_i</ci>
+                <apply>
+                    <times/>
+                    <ci>h8_i</ci>
+                    <ci>wnaca</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k3_i</ci>
+                <apply>
+                    <plus/>
+                    <ci>k3p_i</ci>
+                    <ci>k3pp_i</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k4p_i</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>h3_i</ci>
+                        <ci>wca</ci>
+                    </apply>
+                    <ci>hca</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k4pp_i</ci>
+                <apply>
+                    <times/>
+                    <ci>h2_i</ci>
+                    <ci>wnaca</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k4_i</ci>
+                <apply>
+                    <plus/>
+                    <ci>k4p_i</ci>
+                    <ci>k4pp_i</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k5_i</ci>
+                <ci>kcaoff</ci>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k6_i</ci>
+                <apply>
+                    <times/>
+                    <ci>h6_i</ci>
+                    <ci>cai</ci>
+                    <ci>kcaon</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k7_i</ci>
+                <apply>
+                    <times/>
+                    <ci>h5_i</ci>
+                    <ci>h2_i</ci>
+                    <ci>wna</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k8_i</ci>
+                <apply>
+                    <times/>
+                    <ci>h8_i</ci>
+                    <ci>h11_i</ci>
+                    <ci>wna</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>x1_i</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>k2_i</ci>
+                        <ci>k4_i</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k7_i</ci>
+                            <ci>k6_i</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>k5_i</ci>
+                        <ci>k7_i</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k2_i</ci>
+                            <ci>k3_i</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>x2_i</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>k1_i</ci>
+                        <ci>k7_i</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k4_i</ci>
+                            <ci>k5_i</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>k4_i</ci>
+                        <ci>k6_i</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k1_i</ci>
+                            <ci>k8_i</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>x3_i</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>k1_i</ci>
+                        <ci>k3_i</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k7_i</ci>
+                            <ci>k6_i</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>k8_i</ci>
+                        <ci>k6_i</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k2_i</ci>
+                            <ci>k3_i</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>x4_i</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>k2_i</ci>
+                        <ci>k8_i</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k4_i</ci>
+                            <ci>k5_i</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>k3_i</ci>
+                        <ci>k5_i</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k1_i</ci>
+                            <ci>k8_i</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>E1_i</ci>
+                <apply>
+                    <divide/>
+                    <ci>x1_i</ci>
+                    <apply>
+                        <plus/>
+                        <ci>x1_i</ci>
+                        <ci>x2_i</ci>
+                        <ci>x3_i</ci>
+                        <ci>x4_i</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>E2_i</ci>
+                <apply>
+                    <divide/>
+                    <ci>x2_i</ci>
+                    <apply>
+                        <plus/>
+                        <ci>x1_i</ci>
+                        <ci>x2_i</ci>
+                        <ci>x3_i</ci>
+                        <ci>x4_i</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>E3_i</ci>
+                <apply>
+                    <divide/>
+                    <ci>x3_i</ci>
+                    <apply>
+                        <plus/>
+                        <ci>x1_i</ci>
+                        <ci>x2_i</ci>
+                        <ci>x3_i</ci>
+                        <ci>x4_i</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>E4_i</ci>
+                <apply>
+                    <divide/>
+                    <ci>x4_i</ci>
+                    <apply>
+                        <plus/>
+                        <ci>x1_i</ci>
+                        <ci>x2_i</ci>
+                        <ci>x3_i</ci>
+                        <ci>x4_i</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>allo_i</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <power/>
+                            <apply>
+                                <divide/>
+                                <ci>KmCaAct</ci>
+                                <ci>cai</ci>
+                            </apply>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>JncxNa_i</ci>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <cn cellml:units="dimensionless">3</cn>
+                            <apply>
+                                <minus/>
+                                <apply>
+                                    <times/>
+                                    <ci>E4_i</ci>
+                                    <ci>k7_i</ci>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <ci>E1_i</ci>
+                                    <ci>k8_i</ci>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>E3_i</ci>
+                            <ci>k4pp_i</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>E2_i</ci>
+                        <ci>k3pp_i</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>JncxCa_i</ci>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <times/>
+                        <ci>E2_i</ci>
+                        <ci>k2_i</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>E1_i</ci>
+                        <ci>k1_i</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Gncx</ci>
+                <piecewise>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>Gncx_b</ci>
+                            <cn cellml:units="dimensionless">1.1</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">1</cn>
+                        </apply>
+                    </piece>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>Gncx_b</ci>
+                            <cn cellml:units="dimensionless">1.4</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <ci>Gncx_b</ci>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>INaCa_i</ci>
+                <apply>
+                    <times/>
+                    <apply>
+                        <minus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <ci>INaCa_fractionSS</ci>
+                    </apply>
+                    <ci>Gncx</ci>
+                    <ci>allo_i</ci>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <ci>zna</ci>
+                            <ci>JncxNa_i</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>zca</ci>
+                            <ci>JncxCa_i</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h1_ss</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <divide/>
+                            <ci>nass</ci>
+                            <ci>kna3</ci>
+                        </apply>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <ci>hna</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h2_ss</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>nass</ci>
+                        <ci>hna</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>kna3</ci>
+                        <ci>h1_ss</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h3_ss</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <ci>h1_ss</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h4_ss</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <divide/>
+                            <ci>nass</ci>
+                            <ci>kna1</ci>
+                        </apply>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <divide/>
+                                <ci>nass</ci>
+                                <ci>kna2</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h5_ss</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>nass</ci>
+                        <ci>nass</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>h4_ss</ci>
+                        <ci>kna1</ci>
+                        <ci>kna2</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h6_ss</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <ci>h4_ss</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h7_ss</ci>
+                <apply>
+                    <plus/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <divide/>
+                            <ci>nao</ci>
+                            <ci>kna3</ci>
+                        </apply>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <divide/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>hna</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h8_ss</ci>
+                <apply>
+                    <divide/>
+                    <ci>nao</ci>
+                    <apply>
+                        <times/>
+                        <ci>kna3</ci>
+                        <ci>hna</ci>
+                        <ci>h7_ss</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h9_ss</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <ci>h7_ss</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h10_ss</ci>
+                <apply>
+                    <plus/>
+                    <ci>kasymm</ci>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <times/>
+                        <apply>
+                            <divide/>
+                            <ci>nao</ci>
+                            <ci>kna1</ci>
+                        </apply>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <divide/>
+                                <ci>nao</ci>
+                                <ci>kna2</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h11_ss</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>nao</ci>
+                        <ci>nao</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>h10_ss</ci>
+                        <ci>kna1</ci>
+                        <ci>kna2</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>h12_ss</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <ci>h10_ss</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k1_ss</ci>
+                <apply>
+                    <times/>
+                    <ci>h12_ss</ci>
+                    <ci>cao</ci>
+                    <ci>kcaon</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k2_ss</ci>
+                <ci>kcaoff</ci>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k3p_ss</ci>
+                <apply>
+                    <times/>
+                    <ci>h9_ss</ci>
+                    <ci>wca</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k3pp_ss</ci>
+                <apply>
+                    <times/>
+                    <ci>h8_ss</ci>
+                    <ci>wnaca</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k3_ss</ci>
+                <apply>
+                    <plus/>
+                    <ci>k3p_ss</ci>
+                    <ci>k3pp_ss</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k4p_ss</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>h3_ss</ci>
+                        <ci>wca</ci>
+                    </apply>
+                    <ci>hca</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k4pp_ss</ci>
+                <apply>
+                    <times/>
+                    <ci>h2_ss</ci>
+                    <ci>wnaca</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k4_ss</ci>
+                <apply>
+                    <plus/>
+                    <ci>k4p_ss</ci>
+                    <ci>k4pp_ss</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k5_ss</ci>
+                <ci>kcaoff</ci>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k6_ss</ci>
+                <apply>
+                    <times/>
+                    <ci>h6_ss</ci>
+                    <ci>cass</ci>
+                    <ci>kcaon</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k7_ss</ci>
+                <apply>
+                    <times/>
+                    <ci>h5_ss</ci>
+                    <ci>h2_ss</ci>
+                    <ci>wna</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>k8_ss</ci>
+                <apply>
+                    <times/>
+                    <ci>h8_ss</ci>
+                    <ci>h11_ss</ci>
+                    <ci>wna</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>x1_ss</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>k2_ss</ci>
+                        <ci>k4_ss</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k7_ss</ci>
+                            <ci>k6_ss</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>k5_ss</ci>
+                        <ci>k7_ss</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k2_ss</ci>
+                            <ci>k3_ss</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>x2_ss</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>k1_ss</ci>
+                        <ci>k7_ss</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k4_ss</ci>
+                            <ci>k5_ss</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>k4_ss</ci>
+                        <ci>k6_ss</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k1_ss</ci>
+                            <ci>k8_ss</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>x3_ss</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>k1_ss</ci>
+                        <ci>k3_ss</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k7_ss</ci>
+                            <ci>k6_ss</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>k8_ss</ci>
+                        <ci>k6_ss</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k2_ss</ci>
+                            <ci>k3_ss</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>x4_ss</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>k2_ss</ci>
+                        <ci>k8_ss</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k4_ss</ci>
+                            <ci>k5_ss</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>k3_ss</ci>
+                        <ci>k5_ss</ci>
+                        <apply>
+                            <plus/>
+                            <ci>k1_ss</ci>
+                            <ci>k8_ss</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>E1_ss</ci>
+                <apply>
+                    <divide/>
+                    <ci>x1_ss</ci>
+                    <apply>
+                        <plus/>
+                        <ci>x1_ss</ci>
+                        <ci>x2_ss</ci>
+                        <ci>x3_ss</ci>
+                        <ci>x4_ss</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>E2_ss</ci>
+                <apply>
+                    <divide/>
+                    <ci>x2_ss</ci>
+                    <apply>
+                        <plus/>
+                        <ci>x1_ss</ci>
+                        <ci>x2_ss</ci>
+                        <ci>x3_ss</ci>
+                        <ci>x4_ss</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>E3_ss</ci>
+                <apply>
+                    <divide/>
+                    <ci>x3_ss</ci>
+                    <apply>
+                        <plus/>
+                        <ci>x1_ss</ci>
+                        <ci>x2_ss</ci>
+                        <ci>x3_ss</ci>
+                        <ci>x4_ss</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>E4_ss</ci>
+                <apply>
+                    <divide/>
+                    <ci>x4_ss</ci>
+                    <apply>
+                        <plus/>
+                        <ci>x1_ss</ci>
+                        <ci>x2_ss</ci>
+                        <ci>x3_ss</ci>
+                        <ci>x4_ss</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>allo_ss</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <power/>
+                            <apply>
+                                <divide/>
+                                <ci>KmCaAct</ci>
+                                <ci>cass</ci>
+                            </apply>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>JncxNa_ss</ci>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <cn cellml:units="dimensionless">3</cn>
+                            <apply>
+                                <minus/>
+                                <apply>
+                                    <times/>
+                                    <ci>E4_ss</ci>
+                                    <ci>k7_ss</ci>
+                                </apply>
+                                <apply>
+                                    <times/>
+                                    <ci>E1_ss</ci>
+                                    <ci>k8_ss</ci>
+                                </apply>
+                            </apply>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>E3_ss</ci>
+                            <ci>k4pp_ss</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>E2_ss</ci>
+                        <ci>k3pp_ss</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>JncxCa_ss</ci>
+                <apply>
+                    <minus/>
+                    <apply>
+                        <times/>
+                        <ci>E2_ss</ci>
+                        <ci>k2_ss</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>E1_ss</ci>
+                        <ci>k1_ss</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>INaCa_ss</ci>
+                <apply>
+                    <times/>
+                    <ci>INaCa_fractionSS</ci>
+                    <ci>Gncx</ci>
+                    <ci>allo_ss</ci>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <ci>zna</ci>
+                            <ci>JncxNa_ss</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>zca</ci>
+                            <ci>JncxCa_ss</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="INaK">
+        <variable initial_value="949.5" name="k1p" units="per_millisecond"/>
+        <variable initial_value="182.4" name="k1m" units="per_millisecond"/>
+        <variable initial_value="687.2" name="k2p" units="per_millisecond"/>
+        <variable initial_value="39.4" name="k2m" units="per_millisecond"/>
+        <variable initial_value="1899" name="k3p" units="per_millisecond"/>
+        <variable initial_value="79300" name="k3m" units="per_millisecond"/>
+        <variable initial_value="639" name="k4p" units="per_millisecond"/>
+        <variable initial_value="40" name="k4m" units="per_millisecond"/>
+        <variable initial_value="9.073" name="Knai0" units="millimolar"/>
+        <variable initial_value="27.78" name="Knao0" units="millimolar"/>
+        <variable initial_value="-0.155" name="delta" units="millivolt"/>
+        <variable initial_value="0.5" name="Kki" units="per_millisecond"/>
+        <variable initial_value="0.3582" name="Kko" units="per_millisecond"/>
+        <variable initial_value="0.05" name="MgADP" units="millimolar"/>
+        <variable initial_value="9.8" name="MgATP" units="millimolar"/>
+        <variable initial_value="1.698e-7" name="Kmgatp" units="millimolar"/>
+        <variable initial_value="1e-7" name="H" units="millimolar"/>
+        <variable initial_value="4.2" name="eP" units="dimensionless"/>
+        <variable initial_value="1.698e-7" name="Khp" units="millimolar"/>
+        <variable initial_value="224" name="Knap" units="millimolar"/>
+        <variable initial_value="292" name="Kxkur" units="millimolar"/>
+        <variable name="zk" public_interface="in" units="dimensionless"/>
+        <variable name="zna" public_interface="in" units="dimensionless"/>
+        <variable cmeta:id="membrane_sodium_potassium_pump_current_permeability" initial_value="15.4509" name="Pnak_b" units="milliS_per_microF"/>
+        <variable name="Pnak" units="milliS_per_microF"/>
+        <variable name="celltype" public_interface="in" units="dimensionless"/>
+        <variable name="v" public_interface="in" units="millivolt"/>
+        <variable name="vfrt" public_interface="in" units="dimensionless"/>
+        <variable name="nai" public_interface="in" units="millimolar"/>
+        <variable name="ki" public_interface="in" units="millimolar"/>
+        <variable name="nao" public_interface="in" units="millimolar"/>
+        <variable name="ko" public_interface="in" units="millimolar"/>
+        <variable name="Knai" units="millimolar"/>
+        <variable name="Knao" units="millimolar"/>
+        <variable name="P" units="dimensionless"/>
+        <variable name="a1" units="dimensionless"/>
+        <variable name="b1" units="dimensionless"/>
+        <variable name="a2" units="dimensionless"/>
+        <variable name="b2" units="dimensionless"/>
+        <variable name="a3" units="dimensionless"/>
+        <variable name="b3" units="dimensionless"/>
+        <variable name="a4" units="dimensionless"/>
+        <variable name="b4" units="dimensionless"/>
+        <variable name="x1" units="dimensionless"/>
+        <variable name="x2" units="dimensionless"/>
+        <variable name="x3" units="dimensionless"/>
+        <variable name="x4" units="dimensionless"/>
+        <variable name="E1" units="dimensionless"/>
+        <variable name="E2" units="dimensionless"/>
+        <variable name="E3" units="dimensionless"/>
+        <variable name="E4" units="dimensionless"/>
+        <variable name="JnakNa" units="millimolar_per_millisecond"/>
+        <variable name="JnakK" units="millimolar_per_millisecond"/>
+        <variable cmeta:id="membrane_sodium_potassium_pump_current" name="INaK" public_interface="out" units="microA_per_microF"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>Knai</ci>
+                <apply>
+                    <times/>
+                    <ci>Knai0</ci>
+                    <apply>
+                        <exp/>
+                        <apply>
+                            <divide/>
+                            <apply>
+                                <times/>
+                                <ci>delta</ci>
+                                <ci>vfrt</ci>
+                            </apply>
+                            <cn cellml:units="dimensionless">3</cn>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Knao</ci>
+                <apply>
+                    <times/>
+                    <ci>Knao0</ci>
+                    <apply>
+                        <exp/>
+                        <apply>
+                            <divide/>
+                            <apply>
+                                <times/>
+                                <apply>
+                                    <minus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <ci>delta</ci>
+                                </apply>
+                                <ci>vfrt</ci>
+                            </apply>
+                            <cn cellml:units="dimensionless">3</cn>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>P</ci>
+                <apply>
+                    <divide/>
+                    <ci>eP</ci>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <divide/>
+                            <ci>H</ci>
+                            <ci>Khp</ci>
+                        </apply>
+                        <apply>
+                            <divide/>
+                            <ci>nai</ci>
+                            <ci>Knap</ci>
+                        </apply>
+                        <apply>
+                            <divide/>
+                            <ci>ki</ci>
+                            <ci>Kxkur</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>a1</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>k1p</ci>
+                        <apply>
+                            <power/>
+                            <apply>
+                                <divide/>
+                                <ci>nai</ci>
+                                <ci>Knai</ci>
+                            </apply>
+                            <cn cellml:units="dimensionless">3</cn>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <power/>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <divide/>
+                                        <ci>nai</ci>
+                                        <ci>Knai</ci>
+                                    </apply>
+                                </apply>
+                                <cn cellml:units="dimensionless">3</cn>
+                            </apply>
+                            <apply>
+                                <power/>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <divide/>
+                                        <ci>ki</ci>
+                                        <ci>Kki</ci>
+                                    </apply>
+                                </apply>
+                                <cn cellml:units="dimensionless">2</cn>
+                            </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>b1</ci>
+                <apply>
+                    <times/>
+                    <ci>k1m</ci>
+                    <ci>MgADP</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>a2</ci>
+                <ci>k2p</ci>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>b2</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>k2m</ci>
+                        <apply>
+                            <power/>
+                            <apply>
+                                <divide/>
+                                <ci>nao</ci>
+                                <ci>Knao</ci>
+                            </apply>
+                            <cn cellml:units="dimensionless">3</cn>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <power/>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <divide/>
+                                        <ci>nao</ci>
+                                        <ci>Knao</ci>
+                                    </apply>
+                                </apply>
+                                <cn cellml:units="dimensionless">3</cn>
+                            </apply>
+                            <apply>
+                                <power/>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <divide/>
+                                        <ci>ko</ci>
+                                        <ci>Kko</ci>
+                                    </apply>
+                                </apply>
+                                <cn cellml:units="dimensionless">2</cn>
+                            </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>a3</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>k3p</ci>
+                        <apply>
+                            <power/>
+                            <apply>
+                                <divide/>
+                                <ci>ko</ci>
+                                <ci>Kko</ci>
+                            </apply>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <power/>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <divide/>
+                                        <ci>nao</ci>
+                                        <ci>Knao</ci>
+                                    </apply>
+                                </apply>
+                                <cn cellml:units="dimensionless">3</cn>
+                            </apply>
+                            <apply>
+                                <power/>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <divide/>
+                                        <ci>ko</ci>
+                                        <ci>Kko</ci>
+                                    </apply>
+                                </apply>
+                                <cn cellml:units="dimensionless">2</cn>
+                            </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>b3</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>k3m</ci>
+                        <ci>P</ci>
+                        <ci>H</ci>
+                    </apply>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <divide/>
+                            <ci>MgATP</ci>
+                            <ci>Kmgatp</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>a4</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <ci>k4p</ci>
+                            <ci>MgATP</ci>
+                        </apply>
+                        <ci>Kmgatp</ci>
+                    </apply>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <divide/>
+                            <ci>MgATP</ci>
+                            <ci>Kmgatp</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>b4</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>k4m</ci>
+                        <apply>
+                            <power/>
+                            <apply>
+                                <divide/>
+                                <ci>ki</ci>
+                                <ci>Kki</ci>
+                            </apply>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <power/>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <divide/>
+                                        <ci>nai</ci>
+                                        <ci>Knai</ci>
+                                    </apply>
+                                </apply>
+                                <cn cellml:units="dimensionless">3</cn>
+                            </apply>
+                            <apply>
+                                <power/>
+                                <apply>
+                                    <plus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <apply>
+                                        <divide/>
+                                        <ci>ki</ci>
+                                        <ci>Kki</ci>
+                                    </apply>
+                                </apply>
+                                <cn cellml:units="dimensionless">2</cn>
+                            </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>x1</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>a4</ci>
+                        <ci>a1</ci>
+                        <ci>a2</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>b2</ci>
+                        <ci>b4</ci>
+                        <ci>b3</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>a2</ci>
+                        <ci>b4</ci>
+                        <ci>b3</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>b3</ci>
+                        <ci>a1</ci>
+                        <ci>a2</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>x2</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>b2</ci>
+                        <ci>b1</ci>
+                        <ci>b4</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>a1</ci>
+                        <ci>a2</ci>
+                        <ci>a3</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>a3</ci>
+                        <ci>b1</ci>
+                        <ci>b4</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>a2</ci>
+                        <ci>a3</ci>
+                        <ci>b4</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>x3</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>a2</ci>
+                        <ci>a3</ci>
+                        <ci>a4</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>b3</ci>
+                        <ci>b2</ci>
+                        <ci>b1</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>b2</ci>
+                        <ci>b1</ci>
+                        <ci>a4</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>a3</ci>
+                        <ci>a4</ci>
+                        <ci>b1</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>x4</ci>
+                <apply>
+                    <plus/>
+                    <apply>
+                        <times/>
+                        <ci>b4</ci>
+                        <ci>b3</ci>
+                        <ci>b2</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>a3</ci>
+                        <ci>a4</ci>
+                        <ci>a1</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>b2</ci>
+                        <ci>a4</ci>
+                        <ci>a1</ci>
+                    </apply>
+                    <apply>
+                        <times/>
+                        <ci>b3</ci>
+                        <ci>b2</ci>
+                        <ci>a1</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>E1</ci>
+                <apply>
+                    <divide/>
+                    <ci>x1</ci>
+                    <apply>
+                        <plus/>
+                        <ci>x1</ci>
+                        <ci>x2</ci>
+                        <ci>x3</ci>
+                        <ci>x4</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>E2</ci>
+                <apply>
+                    <divide/>
+                    <ci>x2</ci>
+                    <apply>
+                        <plus/>
+                        <ci>x1</ci>
+                        <ci>x2</ci>
+                        <ci>x3</ci>
+                        <ci>x4</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>E3</ci>
+                <apply>
+                    <divide/>
+                    <ci>x3</ci>
+                    <apply>
+                        <plus/>
+                        <ci>x1</ci>
+                        <ci>x2</ci>
+                        <ci>x3</ci>
+                        <ci>x4</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>E4</ci>
+                <apply>
+                    <divide/>
+                    <ci>x4</ci>
+                    <apply>
+                        <plus/>
+                        <ci>x1</ci>
+                        <ci>x2</ci>
+                        <ci>x3</ci>
+                        <ci>x4</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>JnakNa</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless">3</cn>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <times/>
+                            <ci>E1</ci>
+                            <ci>a3</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>E2</ci>
+                            <ci>b3</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>JnakK</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless">2</cn>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <times/>
+                            <ci>E4</ci>
+                            <ci>b1</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>E3</ci>
+                            <ci>a1</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Pnak</ci>
+                <piecewise>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>Pnak_b</ci>
+                            <cn cellml:units="dimensionless">0.9</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">1</cn>
+                        </apply>
+                    </piece>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>Pnak_b</ci>
+                            <cn cellml:units="dimensionless">0.7</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <ci>Pnak_b</ci>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>INaK</ci>
+                <apply>
+                    <times/>
+                    <ci>Pnak</ci>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <ci>zna</ci>
+                            <ci>JnakNa</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>zk</ci>
+                            <ci>JnakK</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="IKb">
+        <variable name="xkb" units="dimensionless"/>
+        <variable initial_value="0.0189" name="GKb_b" units="milliS_per_microF"/>
+        <variable name="GKb" units="milliS_per_microF"/>
+        <variable name="v" public_interface="in" units="millivolt"/>
+        <variable name="EK" public_interface="in" units="millivolt"/>
+        <variable name="celltype" public_interface="in" units="dimensionless"/>
+        <variable name="IKb" public_interface="out" units="microA_per_microF"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>xkb</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <divide/>
+                                <apply>
+                                    <minus/>
+                                    <apply>
+                                        <minus/>
+                                        <ci>v</ci>
+                                        <cn cellml:units="millivolt">10.8968</cn>
+                                    </apply>
+                                </apply>
+                                <cn cellml:units="millivolt">23.9871</cn>
+                            </apply>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>GKb</ci>
+                <piecewise>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>GKb_b</ci>
+                            <cn cellml:units="dimensionless">0.6</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">1</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <ci>GKb_b</ci>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>IKb</ci>
+                <apply>
+                    <times/>
+                    <ci>GKb</ci>
+                    <ci>xkb</ci>
+                    <apply>
+                        <minus/>
+                        <ci>v</ci>
+                        <ci>EK</ci>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="INab">
+        <variable initial_value="1.9239e-09" name="PNab" units="milliS_per_microF"/>
+        <variable name="INab" public_interface="out" units="microA_per_microF"/>
+        <variable name="nai" public_interface="in" units="millimolar"/>
+        <variable name="nao" public_interface="in" units="millimolar"/>
+        <variable name="vffrt" public_interface="in" units="coulomb_per_mole"/>
+        <variable name="vfrt" public_interface="in" units="dimensionless"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>INab</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>PNab</ci>
+                        <ci>vffrt</ci>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <times/>
+                                <ci>nai</ci>
+                                <apply>
+                                    <exp/>
+                                    <ci>vfrt</ci>
+                                </apply>
+                            </apply>
+                            <ci>nao</ci>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <exp/>
+                            <ci>vfrt</ci>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="ICab">
+        <variable initial_value="5.9194e-08" name="PCab" units="milliS_per_microF"/>
+        <variable name="ICab" public_interface="out" units="microA_per_microF"/>
+        <variable name="cao" public_interface="in" units="millimolar"/>
+        <variable name="cai" public_interface="in" units="millimolar"/>
+        <variable name="gamma_cao" public_interface="in" units="dimensionless"/>
+        <variable name="gamma_cai" public_interface="in" units="dimensionless"/>
+        <variable name="vffrt" public_interface="in" units="coulomb_per_mole"/>
+        <variable name="vfrt" public_interface="in" units="dimensionless"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>ICab</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>PCab</ci>
+                        <cn cellml:units="dimensionless">4</cn>
+                        <ci>vffrt</ci>
+                        <apply>
+                            <minus/>
+                            <apply>
+                                <times/>
+                                <ci>gamma_cai</ci>
+                                <ci>cai</ci>
+                                <apply>
+                                    <exp/>
+                                    <apply>
+                                        <times/>
+                                        <cn cellml:units="dimensionless">2</cn>
+                                        <ci>vfrt</ci>
+                                    </apply>
+                                </apply>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <ci>gamma_cao</ci>
+                                <ci>cao</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <exp/>
+                            <apply>
+                                <times/>
+                                <cn cellml:units="dimensionless">2</cn>
+                                <ci>vfrt</ci>
+                            </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="IpCa">
+        <variable initial_value="5e-04" name="GpCa" units="milliS_per_microF"/>
+        <variable initial_value="0.0005" name="KmCap" units="millimolar"/>
+        <variable cmeta:id="membrane_calcium_pump_current" name="IpCa" public_interface="out" units="microA_per_microF"/>
+        <variable name="cai" public_interface="in" units="millimolar"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>IpCa</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>GpCa</ci>
+                        <ci>cai</ci>
+                    </apply>
+                    <apply>
+                        <plus/>
+                        <ci>KmCap</ci>
+                        <ci>cai</ci>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="ICl">
+        <variable initial_value="0.2843" name="GClCa" units="milliS_per_microF"/>
+        <variable initial_value="1.98e-3" name="GClb" units="milliS_per_microF"/>
+        <variable initial_value="0.1" name="KdClCa" units="millimolar"/>
+        <variable initial_value="1" name="Fjunc" units="dimensionless"/>
+        <variable name="cai" public_interface="in" units="millimolar"/>
+        <variable name="cass" public_interface="in" units="millimolar"/>
+        <variable name="v" public_interface="in" units="millivolt"/>
+        <variable name="ECl" public_interface="in" units="millivolt"/>
+        <variable name="EClss" public_interface="in" units="millivolt"/>
+        <variable name="IClCa_junc" public_interface="out" units="microA_per_microF"/>
+        <variable name="IClCa_sl" public_interface="out" units="microA_per_microF"/>
+        <variable name="IClCa" public_interface="out" units="microA_per_microF"/>
+        <variable name="IClb" public_interface="out" units="microA_per_microF"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>IClCa_junc</ci>
+                <apply>
+                    <times/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <ci>Fjunc</ci>
+                            <ci>GClCa</ci>
+                        </apply>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <divide/>
+                                <ci>KdClCa</ci>
+                                <ci>cass</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <minus/>
+                        <ci>v</ci>
+                        <ci>EClss</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>IClCa_sl</ci>
+                <apply>
+                    <times/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>Fjunc</ci>
+                            </apply>
+                            <ci>GClCa</ci>
+                        </apply>
+                        <apply>
+                            <plus/>
+                            <cn cellml:units="dimensionless">1</cn>
+                            <apply>
+                                <divide/>
+                                <ci>KdClCa</ci>
+                                <ci>cai</ci>
+                            </apply>
+                        </apply>
+                    </apply>
+                    <apply>
+                        <minus/>
+                        <ci>v</ci>
+                        <ci>ECl</ci>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>IClCa</ci>
+                <apply>
+                    <plus/>
+                    <ci>IClCa_junc</ci>
+                    <ci>IClCa_sl</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>IClb</ci>
+                <apply>
+                    <times/>
+                    <ci>GClb</ci>
+                    <apply>
+                        <minus/>
+                        <ci>v</ci>
+                        <ci>ECl</ci>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="diff">
+        <variable name="cai" public_interface="in" units="millimolar"/>
+        <variable name="cass" public_interface="in" units="millimolar"/>
+        <variable name="nai" public_interface="in" units="millimolar"/>
+        <variable name="nass" public_interface="in" units="millimolar"/>
+        <variable name="ki" public_interface="in" units="millimolar"/>
+        <variable name="kss" public_interface="in" units="millimolar"/>
+        <variable name="cli" public_interface="in" units="millimolar"/>
+        <variable name="clss" public_interface="in" units="millimolar"/>
+        <variable initial_value="2.0" name="tauNa" units="millisecond"/>
+        <variable initial_value="2.0" name="tauK" units="millisecond"/>
+        <variable initial_value="0.2" name="tauCa" units="millisecond"/>
+        <variable initial_value="2.0" name="tauCl" units="millisecond"/>
+        <variable name="JdiffNa" public_interface="out" units="millimolar_per_millisecond"/>
+        <variable name="JdiffK" public_interface="out" units="millimolar_per_millisecond"/>
+        <variable name="Jdiff" public_interface="out" units="millimolar_per_millisecond"/>
+        <variable name="JdiffCl" public_interface="out" units="millimolar_per_millisecond"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>JdiffNa</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>nass</ci>
+                        <ci>nai</ci>
+                    </apply>
+                    <ci>tauNa</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>JdiffK</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>kss</ci>
+                        <ci>ki</ci>
+                    </apply>
+                    <ci>tauK</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Jdiff</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>cass</ci>
+                        <ci>cai</ci>
+                    </apply>
+                    <ci>tauCa</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>JdiffCl</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>clss</ci>
+                        <ci>cli</ci>
+                    </apply>
+                    <ci>tauNa</ci>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="ryr">
+        <variable initial_value="4.75" name="bt" units="millisecond"/>
+        <variable name="a_rel" units="millimolar_per_millisecond"/>
+        <variable name="Jrel_inf_b" units="millimolar_per_millisecond"/>
+        <variable name="Jrel_inf" units="millimolar_per_millisecond"/>
+        <variable name="tau_rel_b" units="millisecond"/>
+        <variable name="tau_rel" units="millisecond"/>
+        <variable initial_value="-1.300486e-21" name="Jrel_np" units="millimolar_per_millisecond"/>
+        <variable name="btp" units="millisecond"/>
+        <variable name="a_relp" units="millimolar_per_millisecond"/>
+        <variable name="Jrel_infp_b" units="millimolar_per_millisecond"/>
+        <variable name="Jrel_infp" units="millimolar_per_millisecond"/>
+        <variable name="tau_relp_b" units="millisecond"/>
+        <variable name="tau_relp" units="millisecond"/>
+        <variable initial_value="-7.610714e-20" name="Jrel_p" units="millimolar_per_millisecond"/>
+        <variable initial_value="1.7" name="cajsr_half" units="millimolar"/>
+        <variable name="celltype" public_interface="in" units="dimensionless"/>
+        <variable name="ICaL_ss" public_interface="in" units="microA_per_microF"/>
+        <variable name="cajsr" public_interface="in" units="millimolar"/>
+        <variable name="time" public_interface="in" units="millisecond"/>
+        <variable name="KmCaMK" public_interface="in" units="millimolar"/>
+        <variable name="CaMKa" public_interface="in" units="millimolar"/>
+        <variable name="fJrelp" units="dimensionless"/>
+        <variable cmeta:id="SR_release_current_max" initial_value="1.5378" name="Jrel_b" units="dimensionless"/>
+        <variable cmeta:id="SR_release_current" name="Jrel" public_interface="out" units="millimolar_per_millisecond"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>a_rel</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="millimolar_per_millisecond">0.5</cn>
+                        <ci>bt</ci>
+                    </apply>
+                    <cn cellml:units="millisecond">1</cn>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Jrel_inf_b</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <ci>a_rel</ci>
+                            </apply>
+                            <ci>ICaL_ss</ci>
+                        </apply>
+                        <cn cellml:units="microA_per_microF">1</cn>
+                    </apply>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <power/>
+                            <apply>
+                                <divide/>
+                                <ci>cajsr_half</ci>
+                                <ci>cajsr</ci>
+                            </apply>
+                            <cn cellml:units="dimensionless">8</cn>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Jrel_inf</ci>
+                <piecewise>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>Jrel_inf_b</ci>
+                            <cn cellml:units="dimensionless">1.7</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <ci>Jrel_inf_b</ci>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tau_rel_b</ci>
+                <apply>
+                    <divide/>
+                    <ci>bt</ci>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <divide/>
+                            <cn cellml:units="millimolar">0.0123</cn>
+                            <ci>cajsr</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tau_rel</ci>
+                <piecewise>
+                    <piece>
+                        <cn cellml:units="millisecond">0.001</cn>
+                        <apply>
+                            <lt/>
+                            <ci>tau_rel_b</ci>
+                            <cn cellml:units="millisecond">0.001</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <ci>tau_rel_b</ci>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>Jrel_np</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>Jrel_inf</ci>
+                        <ci>Jrel_np</ci>
+                    </apply>
+                    <ci>tau_rel</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>btp</ci>
+                <apply>
+                    <times/>
+                    <cn cellml:units="dimensionless">1.25</cn>
+                    <ci>bt</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>a_relp</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="millimolar_per_millisecond">0.5</cn>
+                        <ci>btp</ci>
+                    </apply>
+                    <cn cellml:units="millisecond">1</cn>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Jrel_infp_b</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <divide/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <ci>a_relp</ci>
+                            </apply>
+                            <ci>ICaL_ss</ci>
+                        </apply>
+                        <cn cellml:units="microA_per_microF">1</cn>
+                    </apply>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <power/>
+                            <apply>
+                                <divide/>
+                                <ci>cajsr_half</ci>
+                                <ci>cajsr</ci>
+                            </apply>
+                            <cn cellml:units="dimensionless">8</cn>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Jrel_infp</ci>
+                <piecewise>
+                    <piece>
+                        <apply>
+                            <times/>
+                            <ci>Jrel_infp_b</ci>
+                            <cn cellml:units="dimensionless">1.7</cn>
+                        </apply>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <ci>Jrel_infp_b</ci>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tau_relp_b</ci>
+                <apply>
+                    <divide/>
+                    <ci>btp</ci>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <divide/>
+                            <cn cellml:units="millimolar">0.0123</cn>
+                            <ci>cajsr</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>tau_relp</ci>
+                <piecewise>
+                    <piece>
+                        <cn cellml:units="millisecond">0.001</cn>
+                        <apply>
+                            <lt/>
+                            <ci>tau_relp_b</ci>
+                            <cn cellml:units="millisecond">0.001</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <ci>tau_relp_b</ci>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <apply>
+                    <diff/>
+                    <bvar>
+                        <ci>time</ci>
+                    </bvar>
+                    <ci>Jrel_p</ci>
+                </apply>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>Jrel_infp</ci>
+                        <ci>Jrel_p</ci>
+                    </apply>
+                    <ci>tau_relp</ci>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>fJrelp</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <divide/>
+                            <ci>KmCaMK</ci>
+                            <ci>CaMKa</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Jrel</ci>
+                <apply>
+                    <times/>
+                    <ci>Jrel_b</ci>
+                    <apply>
+                        <plus/>
+                        <apply>
+                            <times/>
+                            <apply>
+                                <minus/>
+                                <cn cellml:units="dimensionless">1</cn>
+                                <ci>fJrelp</ci>
+                            </apply>
+                            <ci>Jrel_np</ci>
+                        </apply>
+                        <apply>
+                            <times/>
+                            <ci>fJrelp</ci>
+                            <ci>Jrel_p</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="SERCA">
+        <variable name="upScale" units="dimensionless"/>
+        <variable name="Jupnp" units="millimolar_per_millisecond"/>
+        <variable name="Jupp" units="millimolar_per_millisecond"/>
+        <variable name="KmCaMK" public_interface="in" units="millimolar"/>
+        <variable name="CaMKa" public_interface="in" units="millimolar"/>
+        <variable name="celltype" public_interface="in" units="dimensionless"/>
+        <variable name="cai" public_interface="in" units="millimolar"/>
+        <variable name="cansr" public_interface="in" units="millimolar"/>
+        <variable name="fJupp" units="dimensionless"/>
+        <variable name="Jleak" units="millimolar_per_millisecond"/>
+        <variable cmeta:id="SR_uptake_current" name="Jup" public_interface="out" units="millimolar_per_millisecond"/>
+        <variable cmeta:id="SR_uptake_current_max" initial_value="1.0" name="Jup_b" units="dimensionless"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>upScale</ci>
+                <piecewise>
+                    <piece>
+                        <cn cellml:units="dimensionless">1.3</cn>
+                        <apply>
+                            <eq/>
+                            <ci>celltype</ci>
+                            <cn cellml:units="dimensionless">1</cn>
+                        </apply>
+                    </piece>
+                    <otherwise>
+                        <cn cellml:units="dimensionless">1</cn>
+                    </otherwise>
+                </piecewise>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Jupnp</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>upScale</ci>
+                        <cn cellml:units="dimensionless">0.005425</cn>
+                        <ci>cai</ci>
+                    </apply>
+                    <apply>
+                        <plus/>
+                        <ci>cai</ci>
+                        <cn cellml:units="millimolar">0.00092</cn>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Jupp</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <ci>upScale</ci>
+                        <cn cellml:units="dimensionless">2.75</cn>
+                        <cn cellml:units="dimensionless">0.005425</cn>
+                        <ci>cai</ci>
+                    </apply>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <plus/>
+                            <ci>cai</ci>
+                            <cn cellml:units="millimolar">0.00092</cn>
+                        </apply>
+                        <cn cellml:units="millimolar">0.00017</cn>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>fJupp</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">1</cn>
+                    <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                            <divide/>
+                            <ci>KmCaMK</ci>
+                            <ci>CaMKa</ci>
+                        </apply>
+                    </apply>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Jleak</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <times/>
+                        <cn cellml:units="millimolar_per_millisecond">0.0048825</cn>
+                        <ci>cansr</ci>
+                    </apply>
+                    <cn cellml:units="millimolar">15</cn>
+                </apply>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>Jup</ci>
+                <apply>
+                    <times/>
+                    <ci>Jup_b</ci>
+                    <apply>
+                        <minus/>
+                        <apply>
+                            <plus/>
+                            <apply>
+                                <times/>
+                                <apply>
+                                    <minus/>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                    <ci>fJupp</ci>
+                                </apply>
+                                <ci>Jupnp</ci>
+                            </apply>
+                            <apply>
+                                <times/>
+                                <ci>fJupp</ci>
+                                <ci>Jupp</ci>
+                            </apply>
+                        </apply>
+                        <ci>Jleak</ci>
+                    </apply>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <component name="trans_flux">
+        <variable name="cansr" public_interface="in" units="millimolar"/>
+        <variable name="cajsr" public_interface="in" units="millimolar"/>
+        <variable name="Jtr" public_interface="out" units="millimolar_per_millisecond"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>Jtr</ci>
+                <apply>
+                    <divide/>
+                    <apply>
+                        <minus/>
+                        <ci>cansr</ci>
+                        <ci>cajsr</ci>
+                    </apply>
+                    <cn cellml:units="millisecond">60</cn>
+                </apply>
+            </apply>
+        </math>
+    </component>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="INaL"/>
+        <map_variables variable_1="INaL" variable_2="INaL"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="membrane"/>
+        <map_variables variable_1="Istim" variable_2="Istim"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="trans_flux"/>
+        <map_variables variable_1="cajsr" variable_2="cajsr"/>
+        <map_variables variable_1="cansr" variable_2="cansr"/>
+        <map_variables variable_1="Jtr" variable_2="Jtr"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="SERCA"/>
+        <map_variables variable_1="cai" variable_2="cai"/>
+        <map_variables variable_1="cansr" variable_2="cansr"/>
+        <map_variables variable_1="Jup" variable_2="Jup"/>
+    </connection>
+    <connection>
+        <map_components component_1="SERCA" component_2="environment"/>
+        <map_variables variable_1="celltype" variable_2="celltype"/>
+    </connection>
+    <connection>
+        <map_components component_1="SERCA" component_2="CaMK"/>
+        <map_variables variable_1="KmCaMK" variable_2="KmCaMK"/>
+        <map_variables variable_1="CaMKa" variable_2="CaMKa"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="ryr"/>
+        <map_variables variable_1="cajsr" variable_2="cajsr"/>
+        <map_variables variable_1="Jrel" variable_2="Jrel"/>
+    </connection>
+    <connection>
+        <map_components component_1="ICaL" component_2="ryr"/>
+        <map_variables variable_1="ICaL_ss" variable_2="ICaL_ss"/>
+    </connection>
+    <connection>
+        <map_components component_1="ryr" component_2="CaMK"/>
+        <map_variables variable_1="KmCaMK" variable_2="KmCaMK"/>
+        <map_variables variable_1="CaMKa" variable_2="CaMKa"/>
+    </connection>
+    <connection>
+        <map_components component_1="ryr" component_2="environment"/>
+        <map_variables variable_1="celltype" variable_2="celltype"/>
+        <map_variables variable_1="time" variable_2="time"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="diff"/>
+        <map_variables variable_1="cai" variable_2="cai"/>
+        <map_variables variable_1="cass" variable_2="cass"/>
+        <map_variables variable_1="nai" variable_2="nai"/>
+        <map_variables variable_1="nass" variable_2="nass"/>
+        <map_variables variable_1="ki" variable_2="ki"/>
+        <map_variables variable_1="kss" variable_2="kss"/>
+        <map_variables variable_1="cli" variable_2="cli"/>
+        <map_variables variable_1="clss" variable_2="clss"/>
+        <map_variables variable_1="JdiffK" variable_2="JdiffK"/>
+        <map_variables variable_1="Jdiff" variable_2="Jdiff"/>
+        <map_variables variable_1="JdiffNa" variable_2="JdiffNa"/>
+        <map_variables variable_1="JdiffCl" variable_2="JdiffCl"/>
+    </connection>
+    <connection>
+        <map_components component_1="IpCa" component_2="membrane"/>
+        <map_variables variable_1="IpCa" variable_2="IpCa"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="IpCa"/>
+        <map_variables variable_1="cai" variable_2="cai"/>
+        <map_variables variable_1="IpCa" variable_2="IpCa"/>
+    </connection>
+    <connection>
+        <map_components component_1="extracellular" component_2="ICab"/>
+        <map_variables variable_1="cao" variable_2="cao"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="ICab"/>
+        <map_variables variable_1="cai" variable_2="cai"/>
+        <map_variables variable_1="ICab" variable_2="ICab"/>
+    </connection>
+    <connection>
+        <map_components component_1="ICab" component_2="membrane"/>
+        <map_variables variable_1="vffrt" variable_2="vffrt"/>
+        <map_variables variable_1="vfrt" variable_2="vfrt"/>
+        <map_variables variable_1="ICab" variable_2="ICab"/>
+    </connection>
+    <connection>
+        <map_components component_1="ICaL" component_2="ICab"/>
+        <map_variables variable_1="gamma_cao" variable_2="gamma_cao"/>
+        <map_variables variable_1="gamma_cai" variable_2="gamma_cai"/>
+    </connection>
+    <connection>
+        <map_components component_1="extracellular" component_2="INab"/>
+        <map_variables variable_1="nao" variable_2="nao"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="INab"/>
+        <map_variables variable_1="nai" variable_2="nai"/>
+        <map_variables variable_1="INab" variable_2="INab"/>
+    </connection>
+    <connection>
+        <map_components component_1="INab" component_2="membrane"/>
+        <map_variables variable_1="vffrt" variable_2="vffrt"/>
+        <map_variables variable_1="vfrt" variable_2="vfrt"/>
+        <map_variables variable_1="INab" variable_2="INab"/>
+    </connection>
+    <connection>
+        <map_components component_1="IKb" component_2="membrane"/>
+        <map_variables variable_1="v" variable_2="v"/>
+        <map_variables variable_1="IKb" variable_2="IKb"/>
+    </connection>
+    <connection>
+        <map_components component_1="IKb" component_2="environment"/>
+        <map_variables variable_1="celltype" variable_2="celltype"/>
+    </connection>
+    <connection>
+        <map_components component_1="IKb" component_2="reversal_potentials"/>
+        <map_variables variable_1="EK" variable_2="EK"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="IKb"/>
+        <map_variables variable_1="IKb" variable_2="IKb"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="INaK"/>
+        <map_variables variable_1="ki" variable_2="ki"/>
+        <map_variables variable_1="nai" variable_2="nai"/>
+        <map_variables variable_1="INaK" variable_2="INaK"/>
+    </connection>
+    <connection>
+        <map_components component_1="INaK" component_2="membrane"/>
+        <map_variables variable_1="v" variable_2="v"/>
+        <map_variables variable_1="vfrt" variable_2="vfrt"/>
+        <map_variables variable_1="INaK" variable_2="INaK"/>
+    </connection>
+    <connection>
+        <map_components component_1="INaK" component_2="environment"/>
+        <map_variables variable_1="celltype" variable_2="celltype"/>
+    </connection>
+    <connection>
+        <map_components component_1="INaK" component_2="physical_constants"/>
+        <map_variables variable_1="zna" variable_2="zna"/>
+        <map_variables variable_1="zk" variable_2="zk"/>
+    </connection>
+    <connection>
+        <map_components component_1="extracellular" component_2="INaK"/>
+        <map_variables variable_1="nao" variable_2="nao"/>
+        <map_variables variable_1="ko" variable_2="ko"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="INaCa"/>
+        <map_variables variable_1="cai" variable_2="cai"/>
+        <map_variables variable_1="nai" variable_2="nai"/>
+        <map_variables variable_1="nass" variable_2="nass"/>
+        <map_variables variable_1="cass" variable_2="cass"/>
+        <map_variables variable_1="INaCa_i" variable_2="INaCa_i"/>
+        <map_variables variable_1="INaCa_ss" variable_2="INaCa_ss"/>
+    </connection>
+    <connection>
+        <map_components component_1="INaCa" component_2="membrane"/>
+        <map_variables variable_1="v" variable_2="v"/>
+        <map_variables variable_1="vfrt" variable_2="vfrt"/>
+        <map_variables variable_1="INaCa_i" variable_2="INaCa_i"/>
+        <map_variables variable_1="INaCa_ss" variable_2="INaCa_ss"/>
+    </connection>
+    <connection>
+        <map_components component_1="INaCa" component_2="environment"/>
+        <map_variables variable_1="celltype" variable_2="celltype"/>
+    </connection>
+    <connection>
+        <map_components component_1="INaCa" component_2="physical_constants"/>
+        <map_variables variable_1="zna" variable_2="zna"/>
+        <map_variables variable_1="zca" variable_2="zca"/>
+    </connection>
+    <connection>
+        <map_components component_1="extracellular" component_2="INaCa"/>
+        <map_variables variable_1="nao" variable_2="nao"/>
+        <map_variables variable_1="cao" variable_2="cao"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="IKs"/>
+        <map_variables variable_1="cai" variable_2="cai"/>
+        <map_variables variable_1="IKs" variable_2="IKs"/>
+    </connection>
+    <connection>
+        <map_components component_1="IK1" component_2="membrane"/>
+        <map_variables variable_1="v" variable_2="v"/>
+        <map_variables variable_1="IK1" variable_2="IK1"/>
+    </connection>
+    <connection>
+        <map_components component_1="IK1" component_2="environment"/>
+        <map_variables variable_1="celltype" variable_2="celltype"/>
+    </connection>
+    <connection>
+        <map_components component_1="IKs" component_2="membrane"/>
+        <map_variables variable_1="v" variable_2="v"/>
+        <map_variables variable_1="IKs" variable_2="IKs"/>
+    </connection>
+    <connection>
+        <map_components component_1="IKs" component_2="environment"/>
+        <map_variables variable_1="celltype" variable_2="celltype"/>
+        <map_variables variable_1="time" variable_2="time"/>
+    </connection>
+    <connection>
+        <map_components component_1="IK1" component_2="reversal_potentials"/>
+        <map_variables variable_1="EK" variable_2="EK"/>
+    </connection>
+    <connection>
+        <map_components component_1="IKs" component_2="reversal_potentials"/>
+        <map_variables variable_1="EKs" variable_2="EKs"/>
+    </connection>
+    <connection>
+        <map_components component_1="Ito" component_2="membrane"/>
+        <map_variables variable_1="v" variable_2="v"/>
+        <map_variables variable_1="Ito" variable_2="Ito"/>
+    </connection>
+    <connection>
+        <map_components component_1="INaL" component_2="membrane"/>
+        <map_variables variable_1="v" variable_2="v"/>
+        <map_variables variable_1="INaL" variable_2="INaL"/>
+    </connection>
+    <connection>
+        <map_components component_1="IKr" component_2="membrane"/>
+        <map_variables variable_1="v" variable_2="v"/>
+        <map_variables variable_1="vfrt" variable_2="vfrt"/>
+        <map_variables variable_1="IKr" variable_2="IKr"/>
+    </connection>
+    <connection>
+        <map_components component_1="IKr" component_2="environment"/>
+        <map_variables variable_1="celltype" variable_2="celltype"/>
+        <map_variables variable_1="time" variable_2="time"/>
+    </connection>
+    <connection>
+        <map_components component_1="INaL" component_2="reversal_potentials"/>
+        <map_variables variable_1="ENa" variable_2="ENa"/>
+    </connection>
+    <connection>
+        <map_components component_1="Ito" component_2="reversal_potentials"/>
+        <map_variables variable_1="EK" variable_2="EK"/>
+    </connection>
+    <connection>
+        <map_components component_1="INaL" component_2="CaMK"/>
+        <map_variables variable_1="KmCaMK" variable_2="KmCaMK"/>
+        <map_variables variable_1="CaMKa" variable_2="CaMKa"/>
+    </connection>
+    <connection>
+        <map_components component_1="Ito" component_2="CaMK"/>
+        <map_variables variable_1="KmCaMK" variable_2="KmCaMK"/>
+        <map_variables variable_1="CaMKa" variable_2="CaMKa"/>
+    </connection>
+    <connection>
+        <map_components component_1="INaL" component_2="environment"/>
+        <map_variables variable_1="celltype" variable_2="celltype"/>
+        <map_variables variable_1="time" variable_2="time"/>
+    </connection>
+    <connection>
+        <map_components component_1="ICaL" component_2="environment"/>
+        <map_variables variable_1="celltype" variable_2="celltype"/>
+        <map_variables variable_1="time" variable_2="time"/>
+    </connection>
+    <connection>
+        <map_components component_1="ICaL" component_2="CaMK"/>
+        <map_variables variable_1="KmCaMK" variable_2="KmCaMK"/>
+        <map_variables variable_1="CaMKa" variable_2="CaMKa"/>
+    </connection>
+    <connection>
+        <map_components component_1="CaMK" component_2="environment"/>
+        <map_variables variable_1="time" variable_2="time"/>
+    </connection>
+    <connection>
+        <map_components component_1="membrane" component_2="environment"/>
+        <map_variables variable_1="time" variable_2="time"/>
+    </connection>
+    <connection>
+        <map_components component_1="membrane" component_2="ICaL"/>
+        <map_variables variable_1="v" variable_2="v"/>
+        <map_variables variable_1="vffrt" variable_2="vffrt"/>
+        <map_variables variable_1="vfrt" variable_2="vfrt"/>
+        <map_variables variable_1="ICaL" variable_2="ICaL"/>
+        <map_variables variable_1="ICaNa" variable_2="ICaNa"/>
+        <map_variables variable_1="ICaK" variable_2="ICaK"/>
+    </connection>
+    <connection>
+        <map_components component_1="membrane" component_2="physical_constants"/>
+        <map_variables variable_1="R" variable_2="R"/>
+        <map_variables variable_1="T" variable_2="T"/>
+        <map_variables variable_1="F" variable_2="F"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="physical_constants"/>
+        <map_variables variable_1="R" variable_2="R"/>
+        <map_variables variable_1="T" variable_2="T"/>
+        <map_variables variable_1="F" variable_2="F"/>
+    </connection>
+    <connection>
+        <map_components component_1="physical_constants" component_2="ICaL"/>
+        <map_variables variable_1="T" variable_2="T"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="ICaL"/>
+        <map_variables variable_1="cass" variable_2="cass"/>
+        <map_variables variable_1="nass" variable_2="nass"/>
+        <map_variables variable_1="kss" variable_2="kss"/>
+        <map_variables variable_1="cai" variable_2="cai"/>
+        <map_variables variable_1="nai" variable_2="nai"/>
+        <map_variables variable_1="ki" variable_2="ki"/>
+        <map_variables variable_1="cli" variable_2="cli"/>
+        <map_variables variable_1="clss" variable_2="clss"/>
+        <map_variables variable_1="ICaNa" variable_2="ICaNa"/>
+        <map_variables variable_1="ICaK" variable_2="ICaK"/>
+        <map_variables variable_1="ICaL" variable_2="ICaL"/>
+        <map_variables variable_1="ICaNa_ss" variable_2="ICaNa_ss"/>
+        <map_variables variable_1="ICaK_ss" variable_2="ICaK_ss"/>
+        <map_variables variable_1="ICaL_ss" variable_2="ICaL_ss"/>
+        <map_variables variable_1="ICaNa_i" variable_2="ICaNa_i"/>
+        <map_variables variable_1="ICaK_i" variable_2="ICaK_i"/>
+        <map_variables variable_1="ICaL_i" variable_2="ICaL_i"/>
+    </connection>
+    <connection>
+        <map_components component_1="extracellular" component_2="ICaL"/>
+        <map_variables variable_1="nao" variable_2="nao"/>
+        <map_variables variable_1="ko" variable_2="ko"/>
+        <map_variables variable_1="cao" variable_2="cao"/>
+        <map_variables variable_1="clo" variable_2="clo"/>
+    </connection>
+    <connection>
+        <map_components component_1="extracellular" component_2="IK1"/>
+        <map_variables variable_1="ko" variable_2="ko"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="IK1"/>
+        <map_variables variable_1="IK1" variable_2="IK1"/>
+    </connection>
+    <connection>
+        <map_components component_1="extracellular" component_2="IKr"/>
+        <map_variables variable_1="ko" variable_2="ko"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="IKr"/>
+        <map_variables variable_1="IKr" variable_2="IKr"/>
+    </connection>
+    <connection>
+        <map_components component_1="reversal_potentials" component_2="physical_constants"/>
+        <map_variables variable_1="R" variable_2="R"/>
+        <map_variables variable_1="T" variable_2="T"/>
+        <map_variables variable_1="F" variable_2="F"/>
+        <map_variables variable_1="zna" variable_2="zna"/>
+        <map_variables variable_1="zk" variable_2="zk"/>
+        <map_variables variable_1="zcl" variable_2="zcl"/>
+    </connection>
+    <connection>
+        <map_components component_1="reversal_potentials" component_2="IKr"/>
+        <map_variables variable_1="EK" variable_2="EK"/>
+    </connection>
+    <connection>
+        <map_components component_1="reversal_potentials" component_2="INa"/>
+        <map_variables variable_1="ENa" variable_2="ENa"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="INa"/>
+        <map_variables variable_1="INa" variable_2="INa"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="Ito"/>
+        <map_variables variable_1="Ito" variable_2="Ito"/>
+    </connection>
+    <connection>
+        <map_components component_1="membrane" component_2="INa"/>
+        <map_variables variable_1="v" variable_2="v"/>
+        <map_variables variable_1="INa" variable_2="INa"/>
+    </connection>
+    <connection>
+        <map_components component_1="CaMK" component_2="INa"/>
+        <map_variables variable_1="KmCaMK" variable_2="KmCaMK"/>
+        <map_variables variable_1="CaMKa" variable_2="CaMKa"/>
+    </connection>
+    <connection>
+        <map_components component_1="Ito" component_2="environment"/>
+        <map_variables variable_1="time" variable_2="time"/>
+        <map_variables variable_1="celltype" variable_2="celltype"/>
+    </connection>
+    <connection>
+        <map_components component_1="INa" component_2="environment"/>
+        <map_variables variable_1="time" variable_2="time"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="CaMK"/>
+        <map_variables variable_1="cass" variable_2="cass"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="cell_geometry"/>
+        <map_variables variable_1="Acap" variable_2="Acap"/>
+        <map_variables variable_1="vmyo" variable_2="vmyo"/>
+        <map_variables variable_1="vss" variable_2="vss"/>
+        <map_variables variable_1="vnsr" variable_2="vnsr"/>
+        <map_variables variable_1="vjsr" variable_2="vjsr"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="environment"/>
+        <map_variables variable_1="time" variable_2="time"/>
+        <map_variables variable_1="celltype" variable_2="celltype"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="reversal_potentials"/>
+        <map_variables variable_1="nai" variable_2="nai"/>
+        <map_variables variable_1="ki" variable_2="ki"/>
+        <map_variables variable_1="cli" variable_2="cli"/>
+        <map_variables variable_1="clss" variable_2="clss"/>
+    </connection>
+    <connection>
+        <map_components component_1="extracellular" component_2="reversal_potentials"/>
+        <map_variables variable_1="nao" variable_2="nao"/>
+        <map_variables variable_1="ko" variable_2="ko"/>
+        <map_variables variable_1="clo" variable_2="clo"/>
+    </connection>
+    <connection>
+        <map_components component_1="intracellular_ions" component_2="ICl"/>
+        <map_variables variable_1="cai" variable_2="cai"/>
+        <map_variables variable_1="cass" variable_2="cass"/>
+        <map_variables variable_1="IClCa" variable_2="IClCa"/>
+        <map_variables variable_1="IClCa_junc" variable_2="IClCa_junc"/>
+        <map_variables variable_1="IClCa_sl" variable_2="IClCa_sl"/>
+        <map_variables variable_1="IClb" variable_2="IClb"/>
+    </connection>
+    <connection>
+        <map_components component_1="membrane" component_2="ICl"/>
+        <map_variables variable_1="v" variable_2="v"/>
+        <map_variables variable_1="IClCa" variable_2="IClCa"/>
+        <map_variables variable_1="IClb" variable_2="IClb"/>
+    </connection>
+    <connection>
+        <map_components component_1="reversal_potentials" component_2="ICl"/>
+        <map_variables variable_1="ECl" variable_2="ECl"/>
+        <map_variables variable_1="EClss" variable_2="EClss"/>
+    </connection>
+    <connection>
+        <map_components component_1="I_katp" component_2="membrane"/>
+        <map_variables variable_1="v" variable_2="v"/>
+        <map_variables variable_1="I_katp" variable_2="I_katp"/>
+    </connection>
+    <connection>
+        <map_components component_1="reversal_potentials" component_2="I_katp"/>
+        <map_variables variable_1="EK" variable_2="EK"/>
+    </connection>
+    <connection>
+        <map_components component_1="extracellular" component_2="I_katp"/>
+        <map_variables variable_1="ko" variable_2="ko"/>
+    </connection>
+    <connection>
+        <map_components component_1="I_katp" component_2="intracellular_ions"/>
+        <map_variables variable_1="I_katp" variable_2="I_katp"/>
+    </connection>
+    <!--
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_fast_sodium_current_h_gate">
+<bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+</rdf:Description>
+</rdf:RDF>
+-->
+    <!--
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_fast_sodium_current_j_gate">
+<bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+</rdf:Description>
+</rdf:RDF>
+-->
+    <!--
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#INaL_inactTvar">
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+-->
+    <!--
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_persistent_sodium_current_conductance">
+<bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-		metadata#membrane_persistent_sodium_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+-->
+    <!--
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#INaL_actTvar">
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+-->
+    <!--
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#Ito_actVvar">
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#Ito_actSvar">
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#Ito_actTvar">
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+-->
+    <!--
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_L_type_calcium_current_drivingforce">
+<bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_drivingforce" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+</rdf:Description>
+</rdf:RDF>
+-->
+    <!--
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#ICaL_actVvar">
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#ICaL_actSvar">
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#ICaL_actTvar">
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#ICaL_inactVvar">
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#ICaL_inactSvar">
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#ICaL_inactTVfvar">
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#ICaL_inactTVsvar">
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#ICaL_inactTCfvar">
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#ICaL_inactTCsvar">
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+-->
+    <!--
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_sodium_calcium_exchanger_current_i">
+<bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_i" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+</rdf:Description>
+</rdf:RDF>
+
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_sodium_calcium_exchanger_current_ss">
+<bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_ss" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+</rdf:Description>
+</rdf:RDF>
+-->
+    <!--
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_sodium_potassium_pump_conductance">
+<modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+</rdf:Description>
+</rdf:RDF>
+-->
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_atp_dependent_potassium_current_conductance">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_atp_dependent_potassium_current">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_fast_sodium_current_conductance">
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_persistent_sodium_current_conductance">
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_transient_outward_current_conductance">
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_L_type_calcium_current_conductance">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_rapid_delayed_rectifier_potassium_current_conductance">
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_slow_delayed_rectifier_potassium_current_conductance">
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_inward_rectifier_potassium_current_conductance">
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_sodium_calcium_exchanger_current_conductance">
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_sodium_potassium_pump_current_permeability">
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current_permeability" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#SR_uptake_current_max">
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current_max" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#time">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#time" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#extracellular_sodium_concentration">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_sodium_concentration" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#extracellular_calcium_concentration">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_calcium_concentration" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#extracellular_potassium_concentration">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_potassium_concentration" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_voltage">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_voltage" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_stimulus_current">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_stimulus_current_offset">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_offset" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_stimulus_current_amplitude">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_amplitude" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_stimulus_current_period">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_period" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_stimulus_current_duration">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_duration" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#aCaMK_var">
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#CaMKo_var">
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#cytosolic_sodium_concentration">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_sodium_concentration" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#cytosolic_potassium_concentration">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_potassium_concentration" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#cytosolic_calcium_concentration">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_concentration" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_fast_sodium_current_conductance">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_fast_sodium_current">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_persistent_sodium_current">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_transient_outward_current_conductance">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_transient_outward_current">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_L_type_calcium_current_conductance">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_L_type_calcium_current">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_rapid_delayed_rectifier_potassium_current_conductance">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_rapid_delayed_rectifier_potassium_current">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_slow_delayed_rectifier_potassium_current_conductance">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_slow_delayed_rectifier_potassium_current">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_inward_rectifier_potassium_current_conductance">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_inward_rectifier_potassium_current">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_sodium_calcium_exchanger_current_conductance">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_sodium_potassium_pump_current">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_calcium_pump_current">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#SR_release_current">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#SR_release_current_max">
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current_max" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#SR_uptake_current">
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#SR_uptake_current_max">
+            <modifiable-parameter xmlns="https://chaste.comlab.ox.ac.uk/cellml/ns/pycml#">yes</modifiable-parameter>
+            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current_max" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        </rdf:Description>
+    </rdf:RDF>
+</model>

--- a/tests/cellml_files/noble_1962.cellml
+++ b/tests/cellml_files/noble_1962.cellml
@@ -1,0 +1,790 @@
+<?xml version="1.0"?>
+<!--
+This CellML file was generated on 21/08/2007 at 17:38:21 using:
+
+COR (0.9.31.751)
+Copyright 2002-2007 Dr Alan Garny
+http://COR.physiol.ox.ac.uk/ - COR@physiol.ox.ac.uk
+
+CellML 1.0 was used to generate this cellular model
+http://www.CellML.org/
+-->
+
+<model xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqs="http://www.cellml.org/bqs/1.0#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:ns7="http://www.cellml.org/metadata/simulation/1.0#" name="noble_1962" cmeta:id="noble_1962" xmlns="http://www.cellml.org/cellml/1.0#" xmlns:cellml="http://www.cellml.org/cellml/1.0#" xmlns:cmeta="http://www.cellml.org/metadata/1.0#">
+
+<documentation xmlns="http://cellml.org/tmp-documentation">
+<article>
+  <articleinfo>
+  <title>Noble Purkinje Fibre Model 1962</title>
+  <author>
+    <firstname>Catherine</firstname>
+          <surname>Lloyd</surname>
+    <affiliation>
+      <shortaffil>Auckland Bioengineering Institute, The University of Auckland</shortaffil>
+    </affiliation>
+  </author>
+</articleinfo>
+  <section id="sec_status">
+    <title>Model Status</title>
+    <para>
+      This CellML model runs in COR, JSim and OpenCell to recreate the published results. The units have been checked and they are consistent.
+</para>
+  </section>
+  <sect1 id="sec_structure">
+<title>Model Structure</title>
+
+<para>
+In 1962, Denis Noble published one of the first mathematical models of a cardiac cell.  By adapting the equations of the original Hodgkin-Huxley squid axon model (1952), Noble described the long lasting action and pace-maker potentials of the Purkinje fibres of the heart.  The potassium-current equations differ from those of Hodgkin and Huxley in that the potassium ions are assumed to flow through two types of channel in the membrane.  By contrast, the sodium current equations are very similar to those of Hodgkin and Huxley.
+</para>
+
+<para>
+The main failure of the Noble (1962) model is that it only includes one voltage gated inward current, I<subscript>Na</subscript>.  Calcium currents had not yet been discovered, but there was a clue in the model that something was missing.  The only way the model could be made to work was to greatly extend the voltage range of the sodium current by reducing the voltage dependence of the sodium activation process.  In effect the sodium current was made to serve the function of both the sodium and the calcium channels as far as the plateau is concerned.  There was a clear experimental prediction: either sodium channels in the heart are quantitatively different from those in neurons, or other inward current-carrying channels must exist.  Both predictions are correct.
+</para>
+
+<para>
+The original paper reference is cited below:
+</para>
+
+<para>
+A Modification of the Hodgkin-Huxley Equations Applicable to Purkinje Fibre Action and Pace-maker Potentials, Noble, D. 1962
+            <emphasis>Journal of Physiology</emphasis>
+          , 160, 317-352.  <ulink url="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;list_uids=14480151&amp;dopt=Abstract">PubMed ID: 14480151</ulink>
+</para>
+
+<informalfigure float="0" id="fig_reaction_diagram">
+<mediaobject>
+  <imageobject>
+    <objectinfo>
+      <title>model diagram</title>
+    </objectinfo>
+    <imagedata fileref="hodgkin_1952.png"/>
+  </imageobject>
+</mediaobject>
+<caption>A schematic cell diagram describing the current flows across the cell membrane that are captured in the Noble 1962 model.  Note that this image is identical to the schematic diagram which describes the Hodgkin-Huxley 1952 model.  This is because the Noble 1962 model is based on the HH 1952 model, and the ony differences are in the parameters of the model, and also the gating of the potassium channel - and these differences do not show in the schematic diagram.</caption>
+</informalfigure>
+
+</sect1>
+</article>
+</documentation>
+
+   <units name="per_second">
+      <unit exponent="-1" units="second"/>
+   </units>
+   <units name="millivolt">
+      <unit prefix="milli" units="volt"/>
+   </units>
+   <units name="per_millivolt">
+      <unit exponent="-1" prefix="milli" units="volt"/>
+   </units>
+   <units name="per_millivolt_second">
+      <unit exponent="-1" units="millivolt"/>
+      <unit exponent="-1" units="second"/>
+   </units>
+   <units name="microS">
+      <unit prefix="micro" units="siemens"/>
+   </units>
+   <units name="microF">
+      <unit prefix="micro" units="farad"/>
+   </units>
+   <units name="nanoA">
+      <unit prefix="nano" units="ampere"/>
+   </units>
+   <component name="environment">
+      <variable cmeta:id="environment_time" name="time" public_interface="out" units="second"/>
+   </component>
+   <component name="membrane">
+      <variable cmeta:id="membrane_V" initial_value="-87" name="V" public_interface="out" units="millivolt"/>
+      <variable initial_value="12" name="Cm" units="microF"/>
+      <variable name="time" public_interface="in" units="second"/>
+      <variable name="i_Na" public_interface="in" units="nanoA"/>
+      <variable name="i_K" public_interface="in" units="nanoA"/>
+      <variable name="i_Leak" public_interface="in" units="nanoA"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>V</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <apply>
+                     <plus/>
+                     <ci>i_Na</ci>
+                     <ci>i_K</ci>
+                     <ci>i_Leak</ci>
+                  </apply>
+               </apply>
+               <ci>Cm</ci>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="sodium_channel">
+      <variable cmeta:id="sodium_channel_i_Na" name="i_Na" public_interface="out" units="nanoA"/>
+      <variable initial_value="400000" name="g_Na_max" units="microS"/>
+      <variable name="g_Na" units="microS"/>
+      <variable initial_value="40" name="E_Na" units="millivolt"/>
+      <variable name="time" private_interface="out" public_interface="in" units="second"/>
+      <variable name="V" private_interface="out" public_interface="in" units="millivolt"/>
+      <variable name="m" private_interface="in" units="dimensionless"/>
+      <variable name="h" private_interface="in" units="dimensionless"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>g_Na</ci>
+            <apply>
+               <times/>
+               <apply>
+                  <power/>
+                  <ci>m</ci>
+                  <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="dimensionless">3</cn>
+               </apply>
+               <ci>h</ci>
+               <ci>g_Na_max</ci>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>i_Na</ci>
+            <apply>
+               <times/>
+               <apply>
+                  <plus/>
+                  <ci>g_Na</ci>
+                  <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="microS">140</cn>
+               </apply>
+               <apply>
+                  <minus/>
+                  <ci>V</ci>
+                  <ci>E_Na</ci>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="sodium_channel_m_gate">
+      <variable initial_value="0.01" name="m" public_interface="out" units="dimensionless"/>
+      <variable name="alpha_m" units="per_second"/>
+      <variable name="beta_m" units="per_second"/>
+      <variable name="V" public_interface="in" units="millivolt"/>
+      <variable name="time" public_interface="in" units="second"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>alpha_m</ci>
+            <apply>
+               <divide/>
+               <apply>
+                  <times/>
+                  <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="per_millivolt_second">100</cn>
+                  <apply>
+                     <minus/>
+                     <apply>
+                        <minus/>
+                        <ci>V</ci>
+                     </apply>
+                     <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">48</cn>
+                  </apply>
+               </apply>
+               <apply>
+                  <minus/>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <minus/>
+                           <apply>
+                              <minus/>
+                              <ci>V</ci>
+                           </apply>
+                           <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">48</cn>
+                        </apply>
+                        <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">15</cn>
+                     </apply>
+                  </apply>
+                  <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="dimensionless">1</cn>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>beta_m</ci>
+            <apply>
+               <divide/>
+               <apply>
+                  <times/>
+                  <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="per_millivolt_second">120</cn>
+                  <apply>
+                     <plus/>
+                     <ci>V</ci>
+                     <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">8</cn>
+                  </apply>
+               </apply>
+               <apply>
+                  <minus/>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <plus/>
+                           <ci>V</ci>
+                           <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">8</cn>
+                        </apply>
+                        <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">5</cn>
+                     </apply>
+                  </apply>
+                  <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="dimensionless">1</cn>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>m</ci>
+            </apply>
+            <apply>
+               <minus/>
+               <apply>
+                  <times/>
+                  <ci>alpha_m</ci>
+                  <apply>
+                     <minus/>
+                     <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="dimensionless">1</cn>
+                     <ci>m</ci>
+                  </apply>
+               </apply>
+               <apply>
+                  <times/>
+                  <ci>beta_m</ci>
+                  <ci>m</ci>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="sodium_channel_h_gate">
+      <variable initial_value="0.8" name="h" public_interface="out" units="dimensionless"/>
+      <variable name="alpha_h" units="per_second"/>
+      <variable name="beta_h" units="per_second"/>
+      <variable name="V" public_interface="in" units="millivolt"/>
+      <variable name="time" public_interface="in" units="second"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>alpha_h</ci>
+            <apply>
+               <times/>
+               <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="per_second">170</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <apply>
+                        <minus/>
+                        <apply>
+                           <minus/>
+                           <ci>V</ci>
+                        </apply>
+                        <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">90</cn>
+                     </apply>
+                     <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">20</cn>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>beta_h</ci>
+            <apply>
+               <divide/>
+               <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="per_second">1000</cn>
+               <apply>
+                  <plus/>
+                  <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="dimensionless">1</cn>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <minus/>
+                           <apply>
+                              <minus/>
+                              <ci>V</ci>
+                           </apply>
+                           <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">42</cn>
+                        </apply>
+                        <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">10</cn>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>h</ci>
+            </apply>
+            <apply>
+               <minus/>
+               <apply>
+                  <times/>
+                  <ci>alpha_h</ci>
+                  <apply>
+                     <minus/>
+                     <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="dimensionless">1</cn>
+                     <ci>h</ci>
+                  </apply>
+               </apply>
+               <apply>
+                  <times/>
+                  <ci>beta_h</ci>
+                  <ci>h</ci>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="potassium_channel">
+      <variable cmeta:id="potassium_channel_i_K" name="i_K" public_interface="out" units="nanoA"/>
+      <variable name="g_K1" units="microS"/>
+      <variable name="g_K2" units="microS"/>
+      <variable name="time" private_interface="out" public_interface="in" units="second"/>
+      <variable name="V" private_interface="out" public_interface="in" units="millivolt"/>
+      <variable name="n" private_interface="in" units="dimensionless"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>i_K</ci>
+            <apply>
+               <times/>
+               <apply>
+                  <plus/>
+                  <ci>g_K1</ci>
+                  <ci>g_K2</ci>
+               </apply>
+               <apply>
+                  <plus/>
+                  <ci>V</ci>
+                  <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">100</cn>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>g_K1</ci>
+            <apply>
+               <plus/>
+               <apply>
+                  <times/>
+                  <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="microS">1200</cn>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <minus/>
+                           <apply>
+                              <minus/>
+                              <ci>V</ci>
+                           </apply>
+                           <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">90</cn>
+                        </apply>
+                        <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">50</cn>
+                     </apply>
+                  </apply>
+               </apply>
+               <apply>
+                  <times/>
+                  <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="microS">15</cn>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <plus/>
+                           <ci>V</ci>
+                           <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">90</cn>
+                        </apply>
+                        <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">60</cn>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>g_K2</ci>
+            <apply>
+               <times/>
+               <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="microS">1200</cn>
+               <apply>
+                  <power/>
+                  <ci>n</ci>
+                  <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="dimensionless">4</cn>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="potassium_channel_n_gate">
+      <variable initial_value="0.01" name="n" public_interface="out" units="dimensionless"/>
+      <variable name="alpha_n" units="per_second"/>
+      <variable name="beta_n" units="per_second"/>
+      <variable name="V" public_interface="in" units="millivolt"/>
+      <variable name="time" public_interface="in" units="second"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>alpha_n</ci>
+            <apply>
+               <divide/>
+               <apply>
+                  <times/>
+                  <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="per_millivolt_second">0.1</cn>
+                  <apply>
+                     <minus/>
+                     <apply>
+                        <minus/>
+                        <ci>V</ci>
+                     </apply>
+                     <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">50</cn>
+                  </apply>
+               </apply>
+               <apply>
+                  <minus/>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <minus/>
+                           <apply>
+                              <minus/>
+                              <ci>V</ci>
+                           </apply>
+                           <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">50</cn>
+                        </apply>
+                        <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">10</cn>
+                     </apply>
+                  </apply>
+                  <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="dimensionless">1</cn>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>beta_n</ci>
+            <apply>
+               <times/>
+               <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="per_second">2</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <apply>
+                        <minus/>
+                        <apply>
+                           <minus/>
+                           <ci>V</ci>
+                        </apply>
+                        <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">90</cn>
+                     </apply>
+                     <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="millivolt">80</cn>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>n</ci>
+            </apply>
+            <apply>
+               <minus/>
+               <apply>
+                  <times/>
+                  <ci>alpha_n</ci>
+                  <apply>
+                     <minus/>
+                     <cn xmlns:cellml="http://www.cellml.org/cellml/1.0#" cellml:units="dimensionless">1</cn>
+                     <ci>n</ci>
+                  </apply>
+               </apply>
+               <apply>
+                  <times/>
+                  <ci>beta_n</ci>
+                  <ci>n</ci>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="leakage_current">
+      <variable cmeta:id="leakage_current_i_Leak" name="i_Leak" public_interface="out" units="nanoA"/>
+      <variable initial_value="75" name="g_L" units="microS"/>
+      <variable initial_value="-60" name="E_L" units="millivolt"/>
+      <variable name="time" public_interface="in" units="second"/>
+      <variable name="V" public_interface="in" units="millivolt"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>i_Leak</ci>
+            <apply>
+               <times/>
+               <ci>g_L</ci>
+               <apply>
+                  <minus/>
+                  <ci>V</ci>
+                  <ci>E_L</ci>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <group>
+      <relationship_ref relationship="containment"/>
+      <component_ref component="membrane">
+         <component_ref component="sodium_channel">
+            <component_ref component="sodium_channel_m_gate"/>
+            <component_ref component="sodium_channel_h_gate"/>
+         </component_ref>
+         <component_ref component="potassium_channel">
+            <component_ref component="potassium_channel_n_gate"/>
+         </component_ref>
+         <component_ref component="leakage_current"/>
+      </component_ref>
+   </group>
+   <group>
+      <relationship_ref relationship="encapsulation"/>
+      <component_ref component="sodium_channel">
+         <component_ref component="sodium_channel_m_gate"/>
+         <component_ref component="sodium_channel_h_gate"/>
+      </component_ref>
+      <component_ref component="potassium_channel">
+         <component_ref component="potassium_channel_n_gate"/>
+      </component_ref>
+   </group>
+   <connection>
+      <map_components component_1="membrane" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+   </connection>
+   <connection>
+      <map_components component_1="sodium_channel" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+   </connection>
+   <connection>
+      <map_components component_1="potassium_channel" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+   </connection>
+   <connection>
+      <map_components component_1="leakage_current" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="sodium_channel"/>
+      <map_variables variable_1="V" variable_2="V"/>
+      <map_variables variable_1="i_Na" variable_2="i_Na"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="potassium_channel"/>
+      <map_variables variable_1="V" variable_2="V"/>
+      <map_variables variable_1="i_K" variable_2="i_K"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="leakage_current"/>
+      <map_variables variable_1="V" variable_2="V"/>
+      <map_variables variable_1="i_Leak" variable_2="i_Leak"/>
+   </connection>
+   <connection>
+      <map_components component_1="sodium_channel" component_2="sodium_channel_m_gate"/>
+      <map_variables variable_1="m" variable_2="m"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+   <connection>
+      <map_components component_1="sodium_channel" component_2="sodium_channel_h_gate"/>
+      <map_variables variable_1="h" variable_2="h"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+   <connection>
+      <map_components component_1="potassium_channel" component_2="potassium_channel_n_gate"/>
+      <map_variables variable_1="n" variable_2="n"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+
+
+
+
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Seq rdf:about="rdf:#bde132e3-049c-4da1-8e0a-b4d71b59075d">
+    <rdf:li rdf:resource="rdf:#da0ccc23-6611-4043-a2fa-3c4c3c5cd673"/>
+  </rdf:Seq>
+  <rdf:Description rdf:about="rdf:#93453950-5f08-4363-90bd-aff472ce905e">
+    <vCard:Given xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">Peter</vCard:Given>
+    <vCard:Family xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">Villiger</vCard:Family>
+    <vCard:Other xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">J</vCard:Other>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#a97bf273-bccc-41f4-854c-7ae43ce5cc63">
+    <vCard:Given xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">Catherine</vCard:Given>
+    <vCard:Family xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">Lloyd</vCard:Family>
+    <vCard:Other xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">May</vCard:Other>
+  </rdf:Description>
+  <rdf:Description rdf:about="">
+    <dc:publisher xmlns:dc="http://purl.org/dc/elements/1.1/">Auckland Bioengineering Institute</dc:publisher>
+    <cmeta:comment rdf:resource="rdf:#d2b6f58e-6293-4b50-b751-a6fd3ab1f989"/>
+    <dcterms:created xmlns:dcterms="http://purl.org/dc/terms/" rdf:resource="rdf:#b8e6ba3c-0914-43bf-8037-1424182388cb"/>
+    <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:resource="rdf:#6732b89c-f3f7-4b52-b220-223c5e7e6745"/>
+    <cmeta:modification rdf:resource="rdf:#3fb6dd2b-a5d0-45a9-9b46-ba6b7c47bad6"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#e5a5bd71-3824-4f00-a109-83d494a47634">
+    <vCard:FN xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">Catherine Lloyd</vCard:FN>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#7899ef23-ac75-4102-9531-f07bf2391e36">
+    <rdf:type rdf:resource="http://imc.org/vCard/3.0#internet"/>
+    <rdf:value>c.lloyd@auckland.ac.nz</rdf:value>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#29ec82ff-8775-4a8a-affa-2d23d612180b">
+    <dcterms:W3CDTF xmlns:dcterms="http://purl.org/dc/terms/">2006-03-31</dcterms:W3CDTF>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#4d541118-ca7a-413a-9452-aa240967c7f1">
+    <vCard:N xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" rdf:resource="rdf:#17575034-c342-4933-bab3-b4bb597edd4f"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#e56a5760-9087-425d-add3-5226ae63d572">
+    <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">Journal of Physiology</dc:title>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#6732b89c-f3f7-4b52-b220-223c5e7e6745">
+    <vCard:ORG xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" rdf:resource="rdf:#d8ced495-18cf-42f1-94f0-b660e798b273"/>
+    <vCard:EMAIL xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" rdf:resource="rdf:#7899ef23-ac75-4102-9531-f07bf2391e36"/>
+    <vCard:N xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" rdf:resource="rdf:#a97bf273-bccc-41f4-854c-7ae43ce5cc63"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#1ac643bb-53ff-4666-89b0-819cdf84034c">
+    <vCard:N xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" rdf:resource="rdf:#93453950-5f08-4363-90bd-aff472ce905e"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#3fb6dd2b-a5d0-45a9-9b46-ba6b7c47bad6">
+    <dcterms:modified xmlns:dcterms="http://purl.org/dc/terms/" rdf:resource="rdf:#006c1b33-1b41-4dd2-8bd9-56bc28c91701"/>
+    <rdf:value>This models has been curated using the unit checker in COR and is now unit-consistent.</rdf:value>
+    <cmeta:modifier rdf:resource="rdf:#4d541118-ca7a-413a-9452-aa240967c7f1"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#da0ccc23-6611-4043-a2fa-3c4c3c5cd673">
+    <rdf:type rdf:resource="http://www.cellml.org/bqs/1.0#Person"/>
+    <vCard:N xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" rdf:resource="rdf:#668ac89a-7e3f-4741-b844-d9fccc1d635d"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#967adaad-713c-4689-a962-e69b626e2248">
+    <vCard:ORG xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" rdf:resource="rdf:#e91df542-a47c-43d9-b0ff-b0767719d581"/>
+    <vCard:EMAIL xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" rdf:resource="rdf:#1167aea9-f639-491b-90fd-f4b23332d66d"/>
+    <vCard:N xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" rdf:resource="rdf:#5a885652-b58c-469d-b4d3-8b4923e85adb"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#bab8bf9e-26fc-484f-a5b4-2c4a97a1d123">
+    <dcterms:W3CDTF xmlns:dcterms="http://purl.org/dc/terms/">1962-01-01</dcterms:W3CDTF>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#d8ced495-18cf-42f1-94f0-b660e798b273">
+    <vCard:Orgname xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">The University of Auckland</vCard:Orgname>
+    <vCard:Orgunit xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">Auckland Bioengineering Institute</vCard:Orgunit>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#aea6598d-b850-4aa6-9bb7-76452adba692">
+    <bqs:Pubmed_id xmlns:bqs="http://www.cellml.org/bqs/1.0#">14480151</bqs:Pubmed_id>
+    <bqs:JournalArticle xmlns:bqs="http://www.cellml.org/bqs/1.0#" rdf:resource="rdf:#9e8fe311-1b9c-477b-a358-d83c2537bbf3"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="">
+    <cmeta:modification rdf:resource="rdf:#fa6607cc-772f-491c-b0bd-c8c641feed13"/>
+    <dcterms:created xmlns:dcterms="http://purl.org/dc/terms/" rdf:resource="rdf:#4851a981-8fa2-4fc8-a679-cbdb4a1da137"/>
+    <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:resource="rdf:#967adaad-713c-4689-a962-e69b626e2248"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#b8e6ba3c-0914-43bf-8037-1424182388cb">
+    <dcterms:W3CDTF xmlns:dcterms="http://purl.org/dc/terms/">2007-09-07T00:00:00+00:00</dcterms:W3CDTF>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#9faaf430-3656-4f95-be79-a1e31be11187">
+    <vCard:FN xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">James Lawson</vCard:FN>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#9e8fe311-1b9c-477b-a358-d83c2537bbf3">
+    <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:resource="rdf:#bde132e3-049c-4da1-8e0a-b4d71b59075d"/>
+    <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">A Modification of the Hodgkin-Huxley Equations Applicable to Purkinje Fibre Action and Pace-Maker Potentials</dc:title>
+    <bqs:volume xmlns:bqs="http://www.cellml.org/bqs/1.0#">160</bqs:volume>
+    <bqs:first_page xmlns:bqs="http://www.cellml.org/bqs/1.0#">317</bqs:first_page>
+    <bqs:Journal xmlns:bqs="http://www.cellml.org/bqs/1.0#" rdf:resource="rdf:#e56a5760-9087-425d-add3-5226ae63d572"/>
+    <dcterms:issued xmlns:dcterms="http://purl.org/dc/terms/" rdf:resource="rdf:#bab8bf9e-26fc-484f-a5b4-2c4a97a1d123"/>
+    <bqs:last_page xmlns:bqs="http://www.cellml.org/bqs/1.0#">352</bqs:last_page>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#fa6607cc-772f-491c-b0bd-c8c641feed13">
+    <dcterms:modified xmlns:dcterms="http://purl.org/dc/terms/" rdf:resource="rdf:#29ec82ff-8775-4a8a-affa-2d23d612180b"/>
+    <rdf:value>
+          added metadata
+        </rdf:value>
+    <cmeta:modifier rdf:resource="rdf:#1ac643bb-53ff-4666-89b0-819cdf84034c"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#4851a981-8fa2-4fc8-a679-cbdb4a1da137">
+    <dcterms:W3CDTF xmlns:dcterms="http://purl.org/dc/terms/">2005-05-04</dcterms:W3CDTF>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#017e298c-f99c-41cf-8439-d6a0723656eb">
+    <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:resource="rdf:#e5a5bd71-3824-4f00-a109-83d494a47634"/>
+    <rdf:value>This is the CellML description of Noble's 1962 mathematical model of Purkinje fibre action and pace-maker potentials.  The equations formulated by Hodgkin and Huxley (1952) to describe the electrical activity of squid nerve have been modified to describe the action and pace-maker potentials of the Purkinje fibres of the heart.</rdf:value>
+  </rdf:Description>
+  <rdf:Description rdf:about="#noble_1962">
+    <bqs:reference xmlns:bqs="http://www.cellml.org/bqs/1.0#" rdf:resource="rdf:#aea6598d-b850-4aa6-9bb7-76452adba692"/>
+<bqs:reference xmlns:bqs="http://www.cellml.org/bqs/1.0#" rdf:parseType="Resource">
+  <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:parseType="Resource">
+    <bqs:subject_type>keyword</bqs:subject_type>
+    <rdf:value>
+      <rdf:Bag>
+        <rdf:li>purkinje</rdf:li>
+        <rdf:li>Purkinje fibre</rdf:li>
+        <rdf:li>electrophysiology</rdf:li>
+        <rdf:li>pacemaker</rdf:li>
+        <rdf:li>cardiac</rdf:li>
+        <rdf:li>Hodgkin-Huxley</rdf:li>
+      </rdf:Bag>
+    </rdf:value>
+  </dc:subject>
+</bqs:reference>
+    <cmeta:comment rdf:resource="rdf:#017e298c-f99c-41cf-8439-d6a0723656eb"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#1167aea9-f639-491b-90fd-f4b23332d66d">
+    <rdf:type rdf:resource="http://imc.org/vCard/3.0#internet"/>
+    <rdf:value>penny.noble@physiol.ox.ac.uk</rdf:value>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#d2b6f58e-6293-4b50-b751-a6fd3ab1f989">
+    <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:resource="rdf:#9faaf430-3656-4f95-be79-a1e31be11187"/>
+    <rdf:value>This model has been curated by both Penny Noble and James Lawson and is known to run in COR and PCEnv 0.2.</rdf:value>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#17575034-c342-4933-bab3-b4bb597edd4f">
+    <vCard:Given xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">Penny</vCard:Given>
+    <vCard:Family xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">Noble</vCard:Family>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#006c1b33-1b41-4dd2-8bd9-56bc28c91701">
+    <dcterms:W3CDTF xmlns:dcterms="http://purl.org/dc/terms/">2007-09-07T13:50:26+12:00</dcterms:W3CDTF>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#668ac89a-7e3f-4741-b844-d9fccc1d635d">
+    <vCard:Given xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">D</vCard:Given>
+    <vCard:Family xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">Noble</vCard:Family>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#5a885652-b58c-469d-b4d3-8b4923e85adb">
+    <vCard:Given xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">Penny</vCard:Given>
+    <vCard:Family xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">Noble</vCard:Family>
+  </rdf:Description>
+  <rdf:Description rdf:about="rdf:#e91df542-a47c-43d9-b0ff-b0767719d581">
+    <vCard:Orgname xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">Oxford University</vCard:Orgname>
+  </rdf:Description>
+</rdf:RDF>
+</model>

--- a/tests/test_atoms.py
+++ b/tests/test_atoms.py
@@ -30,26 +30,34 @@ def test_parameter_arguments(parser, trans):
 
     tree = parser.parse(expr)
     result = trans.transform(tree)
-    assert result[0] == atoms.Parameter(name="y", value=sp.sympify(1.0), component="My component")
-    assert result[1] == atoms.Parameter(name="x", value=sp.sympify(42.0), component="My component")
+    assert result[0] == atoms.Parameter(
+        name="y",
+        value=sp.sympify(1.0),
+        components=("My component",),
+    )
+    assert result[1] == atoms.Parameter(
+        name="x",
+        value=sp.sympify(42.0),
+        components=("My component",),
+    )
     assert result[2] == atoms.Parameter(
         name="w",
         value=sp.sympify(10.2),
-        component="My component",
+        components=("My component",),
         unit_str="mM",
     )
     assert result[3] == atoms.Parameter(
         name="v",
         value=sp.sympify(3.14),
         description="Description of v",
-        component="My component",
+        components=("My component",),
         unit_str="mV",
     )
     assert result[4] == atoms.Parameter(
         name="z",
         value=sp.sympify(42.0),
         description="Description of z",
-        component="My component",
+        components=("My component",),
     )
 
 
@@ -70,40 +78,37 @@ def test_states_arguments(parser, trans):
 
     tree = parser.parse(expr)
     result = trans.transform(tree)
-    assert len(result.components) == 2
+    assert len(result.components) == 4
 
     comp1 = result.components[0]
     assert comp1.name == "My component"
 
     assert comp1.states == {
-        atoms.State(name="y", value=sp.sympify(1.0), component="My component"),
-        atoms.State(name="x", value=sp.sympify(42.0), component="My component"),
+        atoms.State(name="y", value=sp.sympify(1.0), components=("My component",)),
+        atoms.State(name="x", value=sp.sympify(42.0), components=("My component",)),
         atoms.State(
             name="w",
             value=sp.sympify(10.2),
-            component="My component",
+            components=("My component", "Some info"),
             unit_str="mM",
-            info="Some info",
         ),
         atoms.State(
             name="v",
             value=sp.sympify(3.14),
             description="Description of v",
-            component="My component",
-            info="Some info",
+            components=("My component", "Some info"),
             unit_str="mV",
         ),
     }
 
-    comp2 = result.components[1]
+    comp2 = result.components[2]
     assert comp2.name == "My other component"
     assert comp2.states == {
         atoms.State(
             name="z",
             value=sp.sympify(42.0),
             description="Description of z",
-            component="My other component",
-            info="other info",
+            components=("My other component", "other info"),
         ),
     }
 

--- a/tests/test_c_codegen.py
+++ b/tests/test_c_codegen.py
@@ -17,7 +17,7 @@ def ode(trans, parser):
     rho=21.0,
     beta=2.4
     )
-    states("My component", "info about states", x=1.0, y=2.0,z=3.05)
+    states("My component", x=1.0, y=2.0,z=3.05)
 
     expressions("My component")
     dy_dt = x*(rho - z) - y # millivolt

--- a/tests/test_cellml.py
+++ b/tests/test_cellml.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import pytest
+import gotranx
+
+here = Path(__file__).parent.absolute()
+
+
+@pytest.mark.parametrize(
+    "cellml_file, num_states, num_parameters",
+    [("noble_1962.cellml", 4, 5), ("ToRORd_dynCl_mid.cellml", 45, 112)],
+)
+def test_cellml_to_gotran(cellml_file, num_states, num_parameters):
+    text = gotranx.cellml.cellml_to_gotran(filename=here / "cellml_files" / cellml_file)
+    ode = gotranx.load.ode_from_string(text)
+    assert ode.num_states == num_states
+    assert ode.num_parameters == num_parameters

--- a/tests/test_cellml.py
+++ b/tests/test_cellml.py
@@ -5,12 +5,16 @@ import gotranx
 here = Path(__file__).parent.absolute()
 
 
+@pytest.mark.parametrize("grouping", ["encapsulation", "containment"])
 @pytest.mark.parametrize(
     "cellml_file, num_states, num_parameters",
     [("noble_1962.cellml", 4, 5), ("ToRORd_dynCl_mid.cellml", 45, 112)],
 )
-def test_cellml_to_gotran(cellml_file, num_states, num_parameters):
-    text = gotranx.cellml.cellml_to_gotran(filename=here / "cellml_files" / cellml_file)
+def test_cellml_to_gotran(grouping, cellml_file, num_states, num_parameters):
+    params = {"grouping": grouping}
+    text = gotranx.cellml.cellml_to_gotran(
+        filename=here / "cellml_files" / cellml_file, params=params
+    )
     ode = gotranx.load.ode_from_string(text)
     assert ode.num_states == num_states
     assert ode.num_parameters == num_parameters

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ def odefile(tmp_path_factory):
     rho=21.0,
     beta=2.4
     )
-    states("My component", "info about states", x=1.0, y=2.0,z=3.05)
+    states("My component", x=1.0, y=2.0,z=3.05)
 
     expressions("My component")
     dy_dt = x*(rho - z) - y # millivolt

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
 import gotranx
 import pytest
+from pathlib import Path
 from typer.testing import CliRunner
 
+here = Path(__file__).parent.absolute()
 runner = CliRunner(mix_stderr=False)
 
 
@@ -40,14 +42,34 @@ def test_cli_license():
 
 
 def test_gotran2py(odefile):
-    result = runner.invoke(gotranx.cli.app, [str(odefile), "--to", ".py"])
+    outfile = odefile.with_suffix(".py")
+    result = runner.invoke(gotranx.cli.app, [str(odefile), "--to", ".py", "-o", str(outfile)])
     assert result.exit_code == 0
     assert "lorentz.py" in result.stdout
     assert "lorentz" in result.stdout
+    assert outfile.is_file()
+    outfile.unlink()
 
 
 def test_gotran2c(odefile):
-    result = runner.invoke(gotranx.cli.app, [str(odefile), "--to", ".h"])
+    outfile = odefile.with_suffix(".h")
+    result = runner.invoke(gotranx.cli.app, [str(odefile), "--to", ".h", "-o", str(outfile)])
     assert result.exit_code == 0
     assert "lorentz.h" in result.stdout
     assert "lorentz" in result.stdout
+    assert outfile.is_file()
+    outfile.with_suffix(".h").unlink()
+
+
+def test_cellml2ode():
+    cellmlfile = here / "cellml_files" / "noble_1962.cellml"
+    out_odefile = cellmlfile.with_suffix(".ode")
+    result = runner.invoke(gotranx.cli.app, [str(cellmlfile), "-o", cellmlfile.with_suffix(".ode")])
+    assert result.exit_code == 0
+
+    assert f"Wrote {out_odefile}" in result.stdout
+    assert out_odefile.is_file()
+    # Check that we can load the file
+    ode = gotranx.load_ode(out_odefile)
+    assert ode is not None
+    out_odefile.unlink()

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -22,23 +22,32 @@ def test_load_ode(path):
         """
     states("First component", "X-gate", x = 1, xr=3.14)
     states("First component", "Y-gate", y = 1)
-    states("Second component", z=1, zi=0.0)
+    states("Second component", z=1)
     parameters("First component", a=1, b=2)
     parameters("Second component", c=3)
 
     expressions("First component")
-    dx_dt=a+1
     d = a + b * 2 - 3 / c
-    dxr_dt= -x + xr
+
+    expressions("First component", "X-gate")
+    dx_dt=a+1
+    dxr_dt = (x / b) - d * xr
+
+    expressions("First component", "Y-gate")
     dy_dt = 2 * d - 1
 
     expressions("Second component")
     dz_dt = 1 + x - y
-    dzi_dt = z + zi
     """,
     )
 
     ode = load_ode(path)
-    assert ode.num_components == 2
-    assert ode.components[0].name == "First component"
-    assert ode.components[1].name == "Second component"
+    assert ode.num_components == 4
+    assert set([c.name for c in ode.components]) == {
+        "First component",
+        "Second component",
+        "X-gate",
+        "Y-gate",
+    }
+    assert ode.num_states == 4
+    assert ode.num_parameters == 3

--- a/tests/test_ode.py
+++ b/tests/test_ode.py
@@ -9,7 +9,7 @@ def test_ODE_with_incomplete_component_raises_ComponentNotCompleteError(parser, 
     result = trans.transform(tree)
     with pytest.raises(exceptions.ComponentNotCompleteError) as e:
         ode.ODE(result.components)
-    assert str(e.value) == "Component None is not complete. Missing state derivatives for ['x']"
+    assert str(e.value) == "Component '' is not complete. Missing state derivatives for ['x']"
 
 
 @pytest.mark.parametrize(
@@ -56,10 +56,14 @@ def test_make_ode(parser, trans):
     parameters("Second component", c=3)
 
     expressions("First component")
-    dx_dt=a+1
     d = a + b * 2 - 3 / c
-    dy_dt = 2 * d - 1
+
+    expressions("First component", "X-gate")
+    dx_dt=a+1
     dxr_dt = (x / b) - d * xr
+
+    expressions("First component", "Y-gate")
+    dy_dt = 2 * d - 1
 
     expressions("Second component")
     dz_dt = 1 + x - y
@@ -71,7 +75,7 @@ def test_make_ode(parser, trans):
     assert result.text == "This is an ODE. Here is another line."
     assert repr(result) == "ODE(TestODE, num_states=4, num_parameters=3)"
 
-    assert result.num_components == 2
+    assert result.num_components == 4
 
     states = result.states
     assert len(states) == result.num_states == 4

--- a/tests/test_python_codegen.py
+++ b/tests/test_python_codegen.py
@@ -16,7 +16,7 @@ def ode(trans, parser):
     rho=21.0,
     beta=2.4
     )
-    states("My component", "info about states", x=1.0, y=2.0,z=3.05)
+    states("My component", x=1.0, y=2.0,z=3.05)
 
     expressions("My component")
     dy_dt = x*(rho - z) - y # millivolt

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -13,17 +13,47 @@ def path():
     path_.unlink()
 
 
-def test_write_ode_file(path, parser, trans):
+def test_write_ode_file_write_dummy(path, parser, trans):
     expr = """
-    parameters(a=0)
-    parameters("My component",
+    # This is an ODE.
+    # Here is another line.
+    # And here is a third line, just to make sure
+    # that the total line length is more than 80 characters.
+    states("First component", "X-gate", x = 1, xr=3.14)
+    states("First component", "Y-gate", y = 1)
+    states("Second component", z=1)
+    parameters("First component", a=1, b=2)
+    parameters("Second component", c=3)
+
+    expressions("First component")
+    d = a + b * 2 - 3 / c
+
+    expressions("First component", "X-gate")
+    dx_dt=a+1
+    dxr_dt = (-d) * xr + (x / b)
+
+    expressions("First component", "Y-gate")
+    dy_dt = 2 * d - 1
+
+    expressions("Second component")
+    dz_dt = 1 + x - y
+    """
+    tree = parser.parse(expr)
+    old_ode = make_ode(*trans.transform(tree), name=path.stem)
+    save.write_ODE_to_ode_file(old_ode, path)
+    ode = load_ode(path)
+    assert ode.simplify() == old_ode.simplify()
+
+
+def test_write_ode_file_write_lorentz(path, parser, trans):
+    expr = """
+    parameters(
     sigma=ScalarParam(12.0, description="Some description"),
     rho=21.0,
     beta=2.4
     )
-    states("My component", "info about states", x=1.0, y=2.0,z=3.05)
+    states(x=1.0, y=2.0,z=3.05)
 
-    expressions("My component")
     dx_dt = sigma*(-x + y)
     dy_dt = x*(rho - z) - y # millivolt
     dz_dt = -beta*z + x*y

--- a/tests/test_schemes.py
+++ b/tests/test_schemes.py
@@ -14,7 +14,7 @@ def ode(trans, parser) -> ODE:
     rho=21.0,
     beta=2.4
     )
-    states("My component", "info about states", x=1.0, z=3.05, y=2.0)
+    states("My component", x=1.0, z=3.05, y=2.0)
 
     expressions("My component")
     dx_dt = sigma*(-x + y)

--- a/tests/test_sympytools.py
+++ b/tests/test_sympytools.py
@@ -14,7 +14,7 @@ def ode(trans, parser) -> ODE:
     rho=21.0,
     beta=2.4
     )
-    states("My component", "info about states", x=1.0, z=3.05, y=2.0)
+    states("My component", x=1.0, z=3.05, y=2.0)
 
     expressions("My component")
     dx_dt = sigma*(-x + y)

--- a/tests/test_transformer_assignments.py
+++ b/tests/test_transformer_assignments.py
@@ -207,13 +207,13 @@ def test_expressions_with_name_only(parser, trans):
     result = trans.transform(tree)
 
     assert len(result) == 2
-    assert result[0].component == "My Component"
+    assert result[0].components == ("My Component",)
     assert result[0].name == "x"
     assert result[0].value.tree == lark.Tree(
         "scientific",
         [lark.Token("SCIENTIFIC_NUMBER", "1")],
     )
-    assert result[1].component == "My Component"
+    assert result[1].components == ("My Component",)
     assert result[1].name == "y"
     assert result[1].value.tree == lark.Tree(
         "scientific",
@@ -231,15 +231,13 @@ def test_expressions_with_name_and_info(parser, trans):
     result = trans.transform(tree)
 
     assert len(result) == 2
-    assert result[0].component == "My Component"
-    assert result[0].info == "Some info"
+    assert result[0].components == ("My Component", "Some info")
     assert result[0].name == "x"
     assert result[0].value.tree == lark.Tree(
         "scientific",
         [lark.Token("SCIENTIFIC_NUMBER", "1")],
     )
-    assert result[1].component == "My Component"
-    assert result[1].info == "Some info"
+    assert result[1].components == ("My Component", "Some info")
     assert result[1].name == "y"
     assert result[1].value.tree == lark.Tree(
         "scientific",
@@ -257,16 +255,14 @@ def test_expressions_with_name_and_info_and_unit(parser, trans):
     result = trans.transform(tree)
 
     assert len(result) == 2
-    assert result[0].component == "My Component"
-    assert result[0].info == "Some info"
+    assert result[0].components == ("My Component", "Some info")
     assert result[0].name == "x"
     assert result[0].value.tree == lark.Tree(
         "scientific",
         [lark.Token("SCIENTIFIC_NUMBER", "1")],
     )
     assert result[0].unit == ureg.Unit("mV")
-    assert result[1].component == "My Component"
-    assert result[1].info == "Some info"
+    assert result[1].components == ("My Component", "Some info")
     assert result[1].name == "y"
     assert result[1].value.tree == lark.Tree(
         "scientific",

--- a/tests/test_transformer_parameters.py
+++ b/tests/test_transformer_parameters.py
@@ -49,8 +49,8 @@ def test_parameters_with_component(parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
     assert len(result) == 2
-    assert result[0] == atoms.Parameter(name="x", value=1, component="My Component")
-    assert result[1] == atoms.Parameter(name="y", value=2, component="My Component")
+    assert result[0] == atoms.Parameter(name="x", value=1, components=("My Component",))
+    assert result[1] == atoms.Parameter(name="y", value=2, components=("My Component",))
 
 
 def test_different_sets_of_parameters(parser, trans):
@@ -65,20 +65,20 @@ def test_different_sets_of_parameters(parser, trans):
     first_component = result[0]
     assert first_component.name == "First component"
     assert first_component.parameters == {
-        atoms.Parameter(name="x", value=1, component="First component"),
-        atoms.Parameter(name="y", value=2, component="First component"),
+        atoms.Parameter(name="x", value=1, components=("First component",)),
+        atoms.Parameter(name="y", value=2, components=("First component",)),
     }
 
     second_component = result[1]
     assert second_component.name == "Second component"
     assert second_component.parameters == {
-        atoms.Parameter(name="z", value=3, component="Second component"),
+        atoms.Parameter(name="z", value=3, components=("Second component",)),
     }
 
     third_component = result[2]
-    assert third_component.name is None
+    assert third_component.name == ""
     assert third_component.parameters == {
-        atoms.Parameter(name="w", value=4, component=None),
+        atoms.Parameter(name="w", value=4, components=("",)),
     }
 
 

--- a/tests/test_transformer_states.py
+++ b/tests/test_transformer_states.py
@@ -52,8 +52,8 @@ def test_states_with_component(parser, trans):
 
     assert len(result) == 2
 
-    assert result[0] == atoms.State(name="x", value=1, component="My component")
-    assert result[1] == atoms.State(name="y", value=2, component="My component")
+    assert result[0] == atoms.State(name="x", value=1, components=("My component",))
+    assert result[1] == atoms.State(name="y", value=2, components=("My component",))
 
 
 def test_states_with_component_and_info(parser, trans):
@@ -66,14 +66,18 @@ def test_states_with_component_and_info(parser, trans):
     assert result[0] == atoms.State(
         name="x",
         value=1,
-        component="My component",
-        info="Some info about the component",
+        components=(
+            "My component",
+            "Some info about the component",
+        ),
     )
     assert result[1] == atoms.State(
         name="y",
         value=2,
-        component="My component",
-        info="Some info about the component",
+        components=(
+            "My component",
+            "Some info about the component",
+        ),
     )
 
 
@@ -85,34 +89,40 @@ def test_different_sets_of_states(parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree).components
 
-    assert len(result) == 3
+    assert len(result) == 4
     first_component = result[0]
+
+    assert first_component.states == result[1].states
     assert first_component.name == "First component"
     assert first_component.states == {
         atoms.State(
             name="x",
             value=1,
-            component="First component",
-            info="Some info about first component",
+            components=(
+                "First component",
+                "Some info about first component",
+            ),
         ),
         atoms.State(
             name="y",
             value=2,
-            component="First component",
-            info="Some info about first component",
+            components=(
+                "First component",
+                "Some info about first component",
+            ),
         ),
     }
 
-    second_component = result[1]
+    second_component = result[2]
     assert second_component.name == "Second component"
     assert second_component.states == {
-        atoms.State(name="z", value=3, component="Second component"),
+        atoms.State(name="z", value=3, components=("Second component",)),
     }
 
-    third_component = result[2]
-    assert third_component.name is None
+    third_component = result[3]
+    assert third_component.name == ""
     assert third_component.states == {
-        atoms.State(name="w", value=4, component=None),
+        atoms.State(name="w", value=4, components=("",)),
     }
 
 


### PR DESCRIPTION
Quite a lot of stuff changed in this PR. First of all we will add the cellml2gotran scripts from old gotran which are essentially the files inside https://github.com/ComputationalPhysiology/gotran/tree/main/gotran/input

Once I did this I realised the the argument that I thought was an "INFO" argument actually are a different compoent, so that
```
states("First component", "Y-gate", y = 1)
```
means that the state `y` belongs to two different components (not that "Y-gate") is just some extra info. So now we will add a new component for each such argument and remove the "INFO" argument. 

For some reason this is also makes it a bit more challenging to consistently same and load the ODEs and when parsing an expression, different syntaxt trees can indeed have the same expression, for example
```
a + b - c = -c + a + b
```
which have different syntax trees. Therefor we will remove this part from the comparison when comparing expressions. We also add a `simplify` method that will make sure to run `sympy.simplify` on all expressions. 
