### PR TITLE
Make it possible to add comments to assignments

### DIFF
--- a/src/gotranx/atoms.py
+++ b/src/gotranx/atoms.py
@@ -135,6 +135,7 @@ class Assignment(Atom):
 
     value: Expression | None = attr.ib()
     expr: sp.Expr = attr.ib(sp.S.Zero)
+    comment: Comment | None = attr.ib(None)
 
     def resolve_expression(self, symbols: dict[str, sp.Symbol]) -> Assignment:
         if self.value is None:
@@ -149,6 +150,7 @@ class Assignment(Atom):
             expr=expr,
             symbol=self.symbol,
             description=self.description,
+            comment=self.comment,
         )
 
     def to_intermediate(self) -> "Intermediate":
@@ -161,6 +163,7 @@ class Assignment(Atom):
             expr=self.expr,
             description=self.description,
             symbol=self.symbol,
+            comment=self.comment,
         )
 
     def to_state_derivative(self, state: State) -> "StateDerivative":
@@ -174,6 +177,7 @@ class Assignment(Atom):
             expr=self.expr,
             description=self.description,
             symbol=self.symbol,
+            comment=self.comment,
         )
 
     def simplify(self) -> "Assignment":
@@ -186,6 +190,7 @@ class Assignment(Atom):
             expr=self.expr.simplify(),
             description=self.description,
             symbol=self.symbol,
+            comment=self.comment,
         )
 
 

--- a/src/gotranx/codegen/ode.py
+++ b/src/gotranx/codegen/ode.py
@@ -173,6 +173,12 @@ def print_ScalarParam(p: atoms.Atom, doprint: Callable[[str], str]) -> str:
 
 def print_assignment(a: atoms.Assignment, doprint: Callable[[str], str]) -> str:
     s = f"{a.name} = {doprint(a.expr)}"
+    unit_or_comment = ""
+    if a.comment is not None:
+        unit_or_comment = a.comment.text
     if a.unit_str is not None and a.unit_str != "1":
-        s += f" # {a.unit_str}"
+        unit_or_comment = a.unit_str
+    if unit_or_comment != "":
+        s += f" # {unit_or_comment}"
+
     return s

--- a/src/gotranx/codegen/ode.py
+++ b/src/gotranx/codegen/ode.py
@@ -84,11 +84,12 @@ class GotranODECodePrinter(BaseGotranODECodePrinter):
     def print_comments(self) -> str:
         if len(self.ode.comments) == 0:
             return ""
-        text = ""
+        text_lst = []
 
         for comment in self.ode.comments:
-            text += reduce(break_comment_at_80, comment.text.split(" "))
+            text_lst.append(reduce(break_comment_at_80, comment.text.split(" ")))
 
+        text = "\n".join(text_lst)
         if len(text) > 0:
             text = "# " + "\n# ".join(text.strip().split("\n"))
             text += "\n\n"

--- a/src/gotranx/exceptions.py
+++ b/src/gotranx/exceptions.py
@@ -40,6 +40,18 @@ class ParameterNotFoundInComponent(GotranxError):
 
 
 @dataclass
+class AssignmentNotFoundInComponent(GotranxError):
+    assignment_name: str
+    component_name: str
+
+    def __str__(self) -> str:
+        return (
+            f"Assignment with name {self.assignment_name!r} "
+            f"not found in component {self.component_name!r}"
+        )
+
+
+@dataclass
 class ComponentNotCompleteError(GotranxError):
     component_name: str
     missing_state_derivatives: list[str]

--- a/src/gotranx/expressions.py
+++ b/src/gotranx/expressions.py
@@ -35,8 +35,6 @@ def binary_op(op: str, fst, snd):
     fst = relational_to_piecewise(fst)
     snd = relational_to_piecewise(snd)
 
-    # breakpoint()
-
     if op == "+":
         return sp.Add(fst, snd, evaluate=False)
     if op == "-":

--- a/src/gotranx/ode.lark
+++ b/src/gotranx/ode.lark
@@ -1,11 +1,10 @@
 ?start: ode
 
-?ode: (parameters | states | expressions | comment) *
+?ode: (parameters | states | expressions | comment | NEWLINE) *
 ?parameter: NAME "=" expression  -> param
     | NAME "=" "ScalarParam" "(" expression ["," "unit" "=" UNIT_STR] ["," "description" "=" DESCRIPTION] ")" -> scalarparam
 
-?assignment : VARIABLE "=" expression [ unit ] [ NEWLINE ]
-?unit: "#" UNIT
+?assignment : VARIABLE "=" expression [ comment ] [ NEWLINE ]
 
 comment : ("#" /.+/)+
 parameters : "parameters" "("  (COMPONENT_NAME ",")* parameter ("," parameter)* [ NEWLINE ] ")"
@@ -92,7 +91,6 @@ MOD: "Mod"
 
 PI: "pi"
 EULER: E2
-I: "i"
 VARIABLE: VALID_ID_START VALID_ID_CHAR*
 VALID_ID_START: "a".."z"|"A".."Z"|"_"
 VALID_ID_CHAR: VALID_ID_START | ("0".."9")
@@ -107,7 +105,7 @@ COMPONENT_NAME: ESCAPED_STRING
 INFO: ESCAPED_STRING
 DESCRIPTION: ESCAPED_STRING
 UNIT_STR: ESCAPED_STRING
-UNIT: NAME ("/" | "*" | "**" SIGN? NUMBER |NAME)*
+
 
 %ignore WS
 %ignore WS_INLINE

--- a/src/gotranx/ode.py
+++ b/src/gotranx/ode.py
@@ -212,7 +212,7 @@ class ODE:
             comments = (atoms.Comment(""),)
 
         self.comments = comments
-        self.text = "".join(comment.text for comment in comments)
+        self.text = " ".join(comment.text for comment in comments)
 
     def __repr__(self) -> str:
         return (

--- a/src/gotranx/ode_component.py
+++ b/src/gotranx/ode_component.py
@@ -94,6 +94,34 @@ class BaseComponent:
                 component_name=self.name,
             )
 
+    def find_assignment(self, assignment_name: str) -> atoms.Assignment:
+        """Find a assignment by name
+
+        Parameters
+        ----------
+        assignment_name : str
+            The name of the assignment
+
+        Returns
+        -------
+        atoms.Assignment
+            The assignment
+
+        Raises
+        ------
+        exceptions.AssignmentNotFoundInComponent
+            If assignment is not found in component
+        """
+
+        for assignment in self.assignments:
+            if assignment.name == assignment_name:
+                return assignment
+        else:
+            raise exceptions.AssignmentNotFoundInComponent(
+                assignment_name=assignment_name,
+                component_name=self.name,
+            )
+
     def is_complete(self) -> bool:
         """Returns true if all states have a corresponding state derivative"""
 

--- a/src/gotranx/save.py
+++ b/src/gotranx/save.py
@@ -14,10 +14,10 @@ def write_ODE_to_ode_file(ode: ODE, path: Path) -> None:
     # Just make sure it is a Path object
     printer = GotranODECodePrinter(ode)
     path = Path(path)
-    text = ""
-    text += printer.print_comments()
-    text += printer.print_states()
-    text += printer.print_parameters()
-    text += printer.print_assignments()
-    path.write_text(text)
+    text = []
+    text.append(printer.print_comments())
+    text.append(printer.print_states())
+    text.append(printer.print_parameters())
+    text.append(printer.print_assignments())
+    path.write_text("".join(text))
     logger.info(f"Wrote {path}")

--- a/tests/test_atoms.py
+++ b/tests/test_atoms.py
@@ -29,29 +29,31 @@ def test_parameter_arguments(parser, trans):
     """
 
     tree = parser.parse(expr)
-    result = trans.transform(tree)
+    components = trans.transform(tree).components
+    result = list(sorted(components[0].parameters, key=lambda x: x.name))
+
     assert result[0] == atoms.Parameter(
-        name="y",
-        value=sp.sympify(1.0),
-        components=("My component",),
-    )
-    assert result[1] == atoms.Parameter(
-        name="x",
-        value=sp.sympify(42.0),
-        components=("My component",),
-    )
-    assert result[2] == atoms.Parameter(
-        name="w",
-        value=sp.sympify(10.2),
-        components=("My component",),
-        unit_str="mM",
-    )
-    assert result[3] == atoms.Parameter(
         name="v",
         value=sp.sympify(3.14),
         description="Description of v",
         components=("My component",),
         unit_str="mV",
+    )
+    assert result[1] == atoms.Parameter(
+        name="w",
+        value=sp.sympify(10.2),
+        components=("My component",),
+        unit_str="mM",
+    )
+    assert result[2] == atoms.Parameter(
+        name="x",
+        value=sp.sympify(42.0),
+        components=("My component",),
+    )
+    assert result[3] == atoms.Parameter(
+        name="y",
+        value=sp.sympify(1.0),
+        components=("My component",),
     )
     assert result[4] == atoms.Parameter(
         name="z",
@@ -123,9 +125,12 @@ def test_comment(parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
 
-    assert len(result.comments) == 1
+    assert len(result.comments) == 2
     assert result.comments[0] == atoms.Comment(
-        text="This is one comment. Here is another comment",
+        text="This is one comment.",
+    )
+    assert result.comments[1] == atoms.Comment(
+        text="Here is another comment",
     )
 
     comp = result.components
@@ -149,7 +154,7 @@ def test_TimeDependentState(parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
     t = sp.Symbol("t")
-    x = result[0]
+    x = list(result.components[0].states)[0]
     x_t = x.to_TimeDependentState(t)
 
     assert str(x.symbol) == "x"

--- a/tests/test_ode.py
+++ b/tests/test_ode.py
@@ -71,7 +71,6 @@ def test_make_ode(parser, trans):
     tree = parser.parse(expr)
 
     result = ode.make_ode(*trans.transform(tree), name="TestODE")
-
     assert result.text == "This is an ODE. Here is another line."
     assert repr(result) == "ODE(TestODE, num_states=4, num_parameters=3)"
 

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -26,17 +26,17 @@ def test_write_ode_file_write_dummy(path, parser, trans):
     parameters("Second component", c=3)
 
     expressions("First component")
-    d = a + b * 2 - 3 / c
+    d = a + b * 2 - 3 / c  # This is a comment
 
     expressions("First component", "X-gate")
-    dx_dt=a+1
-    dxr_dt = (-d) * xr + (x / b)
+    dx_dt=a+1  # This is another comment
+    dxr_dt = (-d) * xr + (x / b) # mV
 
     expressions("First component", "Y-gate")
-    dy_dt = 2 * d - 1
+    dy_dt = 2 * d - 1 # ms
 
     expressions("Second component")
-    dz_dt = 1 + x - y
+    dz_dt = 1 + x - y  # mM
     """
     tree = parser.parse(expr)
     old_ode = make_ode(*trans.transform(tree), name=path.stem)

--- a/tests/test_transformer_parameters.py
+++ b/tests/test_transformer_parameters.py
@@ -94,7 +94,7 @@ def test_different_sets_of_parameters(parser, trans):
             (
                 atoms.Parameter(
                     name="x",
-                    value=1.0,
+                    value=1,
                     unit_str="pA",
                     description="Info about x",
                 ),
@@ -112,16 +112,14 @@ def test_different_sets_of_parameters(parser, trans):
             ),
         ),
         (
-            """
-        parameters(
+            """parameters(
             x=ScalarParam(1, unit="pA", description="Info about x"),
             y=ScalarParam(2.0, unit="mM", description="Info about y")
-        )
-        """,
+        )""",
             (
                 atoms.Parameter(
                     name="x",
-                    value=1.0,
+                    value=1,
                     unit_str="pA",
                     description="Info about x",
                 ),

--- a/tests/test_transformer_states.py
+++ b/tests/test_transformer_states.py
@@ -156,12 +156,10 @@ def test_different_sets_of_states(parser, trans):
             ),
         ),
         (
-            """
-        states(
+            """states(
             x=ScalarParam(1, unit="pA", description="Info about x"),
             y=ScalarParam(2.0, unit="mM", description="Info about y")
-        )
-        """,
+        )""",
             (
                 atoms.State(
                     name="x",


### PR DESCRIPTION
In this PR we add the option to add comments to assignments. 

Comments after assignments can now be added either to represent units or comment. This means that the following
```
x = 1  # mV
```
will be translated to `Assignment(name="x", ..., unit="mV", comment=None)`, while the following
```
x = 1 # This is a comment
```
will be translated to `Assignment(name="x", ..., unit=None, comment=Comment(text="This is a comment"))`. Note that we will first attempt to convert the expression to a valid unit, and if that fail it will be treated as a comment.

## Other changes

- Remove unused module `codecomponent`
- Add newlines as part of the ODE. This was somethinh I needed to add this to get it to work with comments on assignments. This also has some implications that if you try to parse the following expression
```
x = 1
```
Then it will be parsed as a tuple of assignments (which is also the old behaviour). However, if a newline is added before or after the assignment e.g
```
\nx = 1
```
then the expression will be parsed as a `LarkODE` object.