### PR TITLE
Change name from monitor to monitor_values

### DIFF
--- a/src/gotranx/cli/gotran2c.py
+++ b/src/gotranx/cli/gotran2c.py
@@ -50,7 +50,7 @@ def get_code(
         codegen.initial_parameter_values(),
         codegen.initial_state_values(),
         codegen.rhs(),
-        codegen.monitor(),
+        codegen.monitor_values(),
     ]
     if scheme is not None:
         for s in scheme:

--- a/src/gotranx/cli/gotran2py.py
+++ b/src/gotranx/cli/gotran2py.py
@@ -56,7 +56,7 @@ def get_code(
         codegen.initial_parameter_values(),
         codegen.initial_state_values(),
         codegen.rhs(),
-        codegen.monitor(),
+        codegen.monitor_values(),
         _missing_values,
     ]
 

--- a/src/gotranx/codegen/base.py
+++ b/src/gotranx/codegen/base.py
@@ -320,7 +320,7 @@ class CodeGenerator(abc.ABC):
 
         return self._format(code)
 
-    def monitor(self, order: RHSArgument | str = RHSArgument.tsp, use_cse=False) -> str:
+    def monitor_values(self, order: RHSArgument | str = RHSArgument.tsp, use_cse=False) -> str:
         """Generate code for the right hand side of the ODE
 
         Parameters
@@ -364,7 +364,7 @@ class CodeGenerator(abc.ABC):
         shape_info = f"shape = {shape} if len(states.shape) == 1 else ({shape}, states.shape[1])"
 
         code = self.template.method(
-            name="monitor",
+            name="monitor_values",
             args=", ".join(arguments),
             states=states,
             parameters=parameters,

--- a/tests/test_c_codegen.py
+++ b/tests/test_c_codegen.py
@@ -541,8 +541,9 @@ def test_c_codegen_monitor_index(codegen: CCodeGenerator):
 
 
 def test_c_codegen_monitor(codegen: CCodeGenerator):
-    assert codegen.monitor() == (
-        "\nvoid monitor(const double t, const double *__restrict states, const double *__restrict parameters, double *values)"
+    assert codegen.monitor_values() == (
+        "\nvoid monitor_values(const double t, const double *__restrict states, const double *__restrict parameters,"
+        "\n                    double *values)"
         "\n{"
         "\n"
         "\n    // Assign states"

--- a/tests/test_python_codegen.py
+++ b/tests/test_python_codegen.py
@@ -575,8 +575,8 @@ def test_python_remove_unused_forward_generalized_rush_larsen(ode_unused):
 
 
 def test_python_monitored(codegen: PythonCodeGenerator):
-    assert codegen.monitor() == (
-        "def monitor(t, states, parameters):"
+    assert codegen.monitor_values() == (
+        "def monitor_values(t, states, parameters):"
         "\n"
         "\n    # Assign states"
         "\n    x = states[0]"

--- a/tests/test_subodes.py
+++ b/tests/test_subodes.py
@@ -116,8 +116,8 @@ def test_codegen_component_ode_rhs(z_ode_codegen):
 
 
 def test_codegen_component_ode_monitor(z_ode_codegen):
-    assert z_ode_codegen.monitor() == (
-        "def monitor(t, states, parameters, missing_variables):"
+    assert z_ode_codegen.monitor_values() == (
+        "def monitor_values(t, states, parameters, missing_variables):"
         "\n"
         "\n    # Assign states"
         "\n    z = states[0]"


### PR DESCRIPTION
Change name from monitor to monitor_values in function to get the monitor values to not colllide with the dictionary introduced in https://github.com/finsberg/gotranx/pull/44