### PR TITLE
Pass in schemes

### DIFF
--- a/examples/lorentz.py
+++ b/examples/lorentz.py
@@ -162,11 +162,11 @@ print(codegen.initial_state_values())
 # To generate code for a specific scheme you can use the `scheme` method and pass the scheme and the order of the arguments, for example
 
 
-print(codegen.scheme(name="forward_explicit_euler", order="stdp"))
+print(codegen.scheme(f=gotranx.get_scheme("forward_explicit_euler"), order="stdp"))
 
 # Note that with this order you get the arguments in the order  `states`, `time`, `dt` and `parameters`.  Passing `order="ptsd"` will give the following order
 
-print(codegen.scheme(name="forward_explicit_euler", order="ptsd"))
+print(codegen.scheme(f=gotranx.get_scheme("forward_explicit_euler"), order="ptsd"))
 
 # To list the available schemes you can do
 

--- a/examples/new-language/main.py
+++ b/examples/new-language/main.py
@@ -61,7 +61,7 @@ comp = [
     codegen.initial_state_values(),
     codegen.rhs(),
     codegen.monitor_values(),
-    codegen.scheme("forward_explicit_euler")
+    codegen.scheme(gotranx.schemes.get_scheme("forward_explicit_euler"))
 ]
 
 code = codegen._format("\n".join(comp))

--- a/examples/run-python/main.py
+++ b/examples/run-python/main.py
@@ -15,7 +15,7 @@ ode = gotranx.load_ode("ORdmm_Land.ode")
 # Now we can generate code in python using the `cli` subpackage and the `gotran2py` module`. We will also generate code for the generalized rush larsen scheme
 
 code = gotranx.cli.gotran2py.get_code(
-    ode, scheme=[gotranx.schemes.Scheme.forward_generalized_rush_larsen]
+    ode, scheme=[gotranx.schemes.Scheme.generalized_rush_larsen]
 )
 
 # Now we get back the code as a string. To actually execute this code you can either save it to a python file and import it, or you can execute it directly into some namespace (e.g a dictionary). Let's do the latter
@@ -39,7 +39,7 @@ Ca_index = model["state_index"]("cai")
 # Get the index of the active tension from the land model
 Ta_index = model["monitor_index"]("Ta")
 Istim_index = model["monitor_index"]("Istim")
-fgr = model["forward_generalized_rush_larsen"]
+fgr = model["generalized_rush_larsen"]
 mon = model["monitor_values"]
 
 # Let us simulate the model

--- a/src/gotranx/__init__.py
+++ b/src/gotranx/__init__.py
@@ -14,6 +14,7 @@ from . import schemes
 from . import templates
 from . import myokit
 from .load import load_ode
+from .schemes import get_scheme
 from .ode import ODE
 from .ode_component import Component
 from .parser import Parser
@@ -46,6 +47,7 @@ __all__ = [
     "schemes",
     "templates",
     "myokit",
+    "get_scheme",
 ]
 
 import structlog as _structlog

--- a/src/gotranx/_enum.py
+++ b/src/gotranx/_enum.py
@@ -1,0 +1,52 @@
+from enum import Enum, EnumMeta
+# https://stackoverflow.com/questions/62299740/how-do-i-detect-and-invoke-a-function-when-a-python-enum-member-is-accessed
+
+
+class OnAccess(EnumMeta):
+    """
+    runs a user-specified function whenever member is accessed
+    """
+
+    #
+    def __getattribute__(cls, name):
+        obj = super().__getattribute__(name)
+        if isinstance(obj, Enum) and obj._on_access:
+            obj._on_access()
+        return obj
+
+    #
+    def __getitem__(cls, name):
+        member = super().__getitem__(name)
+        if member._on_access:
+            member._on_access()
+        return member
+
+    #
+    def __call__(cls, value, names=None, *, module=None, qualname=None, type=None, start=1):
+        obj = super().__call__(
+            value, names, module=module, qualname=qualname, type=type, start=start
+        )
+        if isinstance(obj, Enum) and obj._on_access:
+            obj._on_access()
+        return obj
+
+
+class DeprecatedEnum(Enum, metaclass=OnAccess):
+    #
+    def __new__(cls, value, *args):
+        member = object.__new__(cls)
+        member._value_ = value
+        member._args = args
+        member._on_access = member.deprecate if args else None
+        return member
+
+    #
+    def deprecate(self):
+        args = (self.name,) + self._args
+        import warnings
+
+        warnings.warn(
+            "member %r is deprecated; %s" % args,
+            DeprecationWarning,
+            stacklevel=3,
+        )

--- a/src/gotranx/cli/gotran2c.py
+++ b/src/gotranx/cli/gotran2c.py
@@ -5,7 +5,7 @@ import structlog
 
 from ..codegen.c import CCodeGenerator
 from ..load import load_ode
-from ..schemes import Scheme
+from ..schemes import Scheme, get_scheme
 from ..ode import ODE
 
 logger = structlog.get_logger()
@@ -53,7 +53,7 @@ def get_code(
     ]
     if scheme is not None:
         for s in scheme:
-            comp.append(codegen.scheme(s.value))
+            comp.append(codegen.scheme(get_scheme(s.value)))
 
     return codegen._format("\n".join(comp))
 

--- a/src/gotranx/cli/gotran2py.py
+++ b/src/gotranx/cli/gotran2py.py
@@ -5,7 +5,7 @@ import structlog
 
 from ..codegen.python import PythonCodeGenerator
 from ..load import load_ode
-from ..schemes import Scheme
+from ..schemes import Scheme, get_scheme
 from ..ode import ODE
 
 logger = structlog.get_logger()
@@ -61,7 +61,7 @@ def get_code(
 
     if scheme is not None:
         for s in scheme:
-            comp.append(codegen.scheme(s.value))
+            comp.append(codegen.scheme(get_scheme(s.value)))
 
     return codegen._format("\n".join(comp))
 

--- a/src/gotranx/codegen/base.py
+++ b/src/gotranx/codegen/base.py
@@ -431,13 +431,13 @@ class CodeGenerator(abc.ABC):
 
         return self._format(code)
 
-    def scheme(self, name: str, order=SchemeArgument.stdp) -> str:
+    def scheme(self, f: schemes.scheme_func, order=SchemeArgument.stdp) -> str:
         """Generate code for the scheme
 
         Parameters
         ----------
-        name : str
-            The name of the scheme
+        f : schemes.scheme_func
+            Function for generating the scheme
         order : SchemeArgument | str, optional
             The order of the arguments, by default SchemeArgument.stdp
 
@@ -457,7 +457,6 @@ class CodeGenerator(abc.ABC):
             arguments += ["missing_variables"]
 
         dt = sympy.Symbol("dt")
-        f = schemes.get_scheme(name)
         eqs = f(
             self.ode,
             dt,
@@ -468,7 +467,7 @@ class CodeGenerator(abc.ABC):
         values = "\n".join(eqs)
 
         code = self.template.method(
-            name=name,
+            name=f.__code__.co_name,
             args=", ".join(arguments),
             states=states,
             parameters=parameters,

--- a/src/gotranx/schemes.py
+++ b/src/gotranx/schemes.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 import typing
-import sympy
+from types import CodeType
 
+import sympy
 from structlog import get_logger
 
 from . import atoms
@@ -33,6 +34,8 @@ class printer_func(typing.Protocol):
 
 
 class scheme_func(typing.Protocol):
+    __code__: CodeType
+
     def __call__(
         self,
         ode: ODE,
@@ -56,11 +59,15 @@ class Scheme(DeprecatedEnum):
 def get_scheme(scheme: str) -> scheme_func:
     """Get the scheme function from a string"""
     if scheme in ["forward_euler", "forward_explicit_euler", "euler", "explicit_euler"]:
-        return explicit_euler
+        func = explicit_euler
     elif scheme in ["forward_generalized_rush_larsen", "generalized_rush_larsen"]:
-        return generalized_rush_larsen
+        func = generalized_rush_larsen
     else:
         raise ValueError(f"Unknown scheme {scheme}")
+
+    # Replace the name of the function
+    func.__code__ = func.__code__.replace(co_name=scheme)
+    return func
 
 
 def list_schemes() -> list[str]:

--- a/src/gotranx/schemes.py
+++ b/src/gotranx/schemes.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 import typing
 import sympy
-from enum import Enum
 
 from structlog import get_logger
 
 from . import atoms
 from .ode import ODE
 from . import sympytools
+from ._enum import DeprecatedEnum
 
 logger = get_logger()
 
@@ -43,17 +43,22 @@ class scheme_func(typing.Protocol):
     ) -> list[str]: ...
 
 
-class Scheme(str, Enum):
-    forward_explicit_euler = "forward_explicit_euler"
-    forward_generalized_rush_larsen = "forward_generalized_rush_larsen"
+class Scheme(DeprecatedEnum):
+    explicit_euler = "explicit_euler"
+    generalized_rush_larsen = "generalized_rush_larsen"
+    forward_explicit_euler = "forward_explicit_euler", "Use 'explicit_euler' instead"
+    forward_generalized_rush_larsen = (
+        "forward_generalized_rush_larsen",
+        "Use 'generalized_rush_larsen' instead",
+    )
 
 
 def get_scheme(scheme: str) -> scheme_func:
     """Get the scheme function from a string"""
     if scheme in ["forward_euler", "forward_explicit_euler", "euler", "explicit_euler"]:
-        return forward_explicit_euler
+        return explicit_euler
     elif scheme in ["forward_generalized_rush_larsen", "generalized_rush_larsen"]:
-        return forward_generalized_rush_larsen
+        return generalized_rush_larsen
     else:
         raise ValueError(f"Unknown scheme {scheme}")
 
@@ -99,7 +104,7 @@ def fraction_numerator_is_nonzero(expr):
         return False
 
 
-def forward_explicit_euler(
+def explicit_euler(
     ode: ODE,
     dt: sympy.Symbol,
     name: str = "values",
@@ -151,7 +156,7 @@ def forward_explicit_euler(
     return eqs
 
 
-def forward_generalized_rush_larsen(
+def generalized_rush_larsen(
     ode: ODE,
     dt: sympy.Symbol,
     name: str = "values",

--- a/tests/test_c_codegen.py
+++ b/tests/test_c_codegen.py
@@ -3,6 +3,7 @@ import sys
 from unittest import mock
 
 import pytest
+from gotranx.schemes import get_scheme
 from gotranx.codegen import CCodeGenerator
 from gotranx.codegen import RHSArgument
 from gotranx.ode import make_ode
@@ -132,7 +133,7 @@ def test_c_codegen_rhs(order: str, arguments: str, codegen: CCodeGenerator):
 
 
 def test_c_codegen_forward_euler(codegen: CCodeGenerator):
-    assert codegen.scheme("forward_euler") == (
+    assert codegen.scheme(get_scheme("forward_euler")) == (
         "\nvoid forward_euler(const double *__restrict states, const double t, const double dt,"
         "\n                   const double *__restrict parameters, double *values)"
         "\n{"
@@ -161,7 +162,7 @@ def test_c_codegen_forward_euler(codegen: CCodeGenerator):
 
 
 def test_c_codegen_forward_generalized_rush_larsen(codegen: CCodeGenerator):
-    assert codegen.scheme("forward_generalized_rush_larsen") == (
+    assert codegen.scheme(get_scheme("forward_generalized_rush_larsen")) == (
         "\nvoid forward_generalized_rush_larsen(const double *__restrict states, const double t, const double dt,"
         "\n                                     const double *__restrict parameters, double *values)"
         "\n{"
@@ -258,7 +259,7 @@ def test_c_remove_unused_rhs(ode_unused):
 
 def test_c_remove_unused_forward_explicit_euler(ode_unused):
     codegen_orig = CCodeGenerator(ode_unused)
-    assert codegen_orig.scheme("forward_euler") == (
+    assert codegen_orig.scheme(get_scheme("forward_euler")) == (
         "\nvoid forward_euler(const double *__restrict states, const double t, const double dt,"
         "\n                   const double *__restrict parameters, double *values)"
         "\n{"
@@ -290,7 +291,7 @@ def test_c_remove_unused_forward_explicit_euler(ode_unused):
         "\n"
     )
     codegen_remove = CCodeGenerator(ode_unused, remove_unused=True)
-    assert codegen_remove.scheme("forward_euler") == (
+    assert codegen_remove.scheme(get_scheme("forward_euler")) == (
         "\nvoid forward_euler(const double *__restrict states, const double t, const double dt,"
         "\n                   const double *__restrict parameters, double *values)"
         "\n{"
@@ -322,7 +323,7 @@ def test_c_remove_unused_forward_explicit_euler(ode_unused):
 
 def test_c_remove_unused_forward_generalized_rush_larsen(ode_unused):
     codegen_orig = CCodeGenerator(ode_unused)
-    assert codegen_orig.scheme("forward_generalized_rush_larsen") == (
+    assert codegen_orig.scheme(get_scheme("forward_generalized_rush_larsen")) == (
         "\nvoid forward_generalized_rush_larsen(const double *__restrict states, const double t, const double dt,"
         "\n                                     const double *__restrict parameters, double *values)"
         "\n{"
@@ -360,7 +361,7 @@ def test_c_remove_unused_forward_generalized_rush_larsen(ode_unused):
         "\n"
     )
     codegen_remove = CCodeGenerator(ode_unused, remove_unused=True)
-    assert codegen_remove.scheme("forward_generalized_rush_larsen") == (
+    assert codegen_remove.scheme(get_scheme("forward_generalized_rush_larsen")) == (
         "\nvoid forward_generalized_rush_larsen(const double *__restrict states, const double t, const double dt,"
         "\n                                     const double *__restrict parameters, double *values)"
         "\n{"

--- a/tests/test_python_codegen.py
+++ b/tests/test_python_codegen.py
@@ -2,6 +2,7 @@ import sys
 from unittest import mock
 
 import pytest
+from gotranx.schemes import get_scheme
 from gotranx.codegen import PythonCodeGenerator
 from gotranx.codegen import RHSArgument
 from gotranx.ode import make_ode
@@ -213,7 +214,7 @@ def test_python_codegen_rhs(order: str, arguments: str, codegen: PythonCodeGener
 
 
 def test_python_codegen_forward_explicit_euler(codegen: PythonCodeGenerator):
-    assert codegen.scheme("forward_explicit_euler") == (
+    assert codegen.scheme(get_scheme("forward_explicit_euler")) == (
         "def forward_explicit_euler(states, t, dt, parameters):"
         "\n"
         "\n    # Assign states"
@@ -245,7 +246,7 @@ def test_python_codegen_forward_explicit_euler(codegen: PythonCodeGenerator):
 
 
 def test_python_codegen_forward_generalized_rush_larsen(codegen: PythonCodeGenerator):
-    assert codegen.scheme("forward_generalized_rush_larsen") == (
+    assert codegen.scheme(get_scheme("forward_generalized_rush_larsen")) == (
         "def forward_generalized_rush_larsen(states, t, dt, parameters):"
         "\n"
         "\n    # Assign states"
@@ -414,7 +415,7 @@ def test_python_remove_unused_rhs(ode_unused):
 
 def test_python_remove_unused_forward_explicit_euler(ode_unused):
     codegen_orig = PythonCodeGenerator(ode_unused)
-    assert codegen_orig.scheme("forward_explicit_euler") == (
+    assert codegen_orig.scheme(get_scheme("forward_explicit_euler")) == (
         "def forward_explicit_euler(states, t, dt, parameters):"
         "\n"
         "\n    # Assign states"
@@ -447,7 +448,7 @@ def test_python_remove_unused_forward_explicit_euler(ode_unused):
         "\n"
     )
     codegen_remove = PythonCodeGenerator(ode_unused, remove_unused=True)
-    assert codegen_remove.scheme("forward_explicit_euler") == (
+    assert codegen_remove.scheme(get_scheme("forward_explicit_euler")) == (
         "def forward_explicit_euler(states, t, dt, parameters):"
         "\n"
         "\n    # Assign states"
@@ -480,7 +481,7 @@ def test_python_remove_unused_forward_explicit_euler(ode_unused):
 
 def test_python_remove_unused_forward_generalized_rush_larsen(ode_unused):
     codegen_orig = PythonCodeGenerator(ode_unused)
-    assert codegen_orig.scheme("forward_generalized_rush_larsen") == (
+    assert codegen_orig.scheme(get_scheme("forward_generalized_rush_larsen")) == (
         "def forward_generalized_rush_larsen(states, t, dt, parameters):"
         "\n"
         "\n    # Assign states"
@@ -528,7 +529,7 @@ def test_python_remove_unused_forward_generalized_rush_larsen(ode_unused):
         "\n"
     )
     codegen_remove = PythonCodeGenerator(ode_unused, remove_unused=True)
-    assert codegen_remove.scheme("forward_generalized_rush_larsen") == (
+    assert codegen_remove.scheme(get_scheme("forward_generalized_rush_larsen")) == (
         "def forward_generalized_rush_larsen(states, t, dt, parameters):"
         "\n"
         "\n    # Assign states"

--- a/tests/test_schemes.py
+++ b/tests/test_schemes.py
@@ -27,9 +27,9 @@ def ode(trans, parser) -> ODE:
     return make_ode(*trans.transform(tree))
 
 
-def test_forward_explicit_euler(ode: ODE):
+def test_explicit_euler(ode: ODE):
     dt = sympy.Symbol("dt")
-    eqs = schemes.forward_explicit_euler(ode, dt)
+    eqs = schemes.explicit_euler(ode, dt)
     assert len(eqs) == 8
 
     assert eqs[0] == "y_int = x*(rho - z)"
@@ -42,9 +42,9 @@ def test_forward_explicit_euler(ode: ODE):
     assert eqs[7] == "values[2] = dt*dz_dt + z"
 
 
-def test_forward_generalized_rush_larsen(ode: ODE):
+def test_generalized_rush_larsen(ode: ODE):
     dt = sympy.Symbol("dt")
-    eqs = schemes.forward_generalized_rush_larsen(ode, dt)
+    eqs = schemes.generalized_rush_larsen(ode, dt)
 
     assert len(eqs) == 10
 

--- a/tests/test_subodes.py
+++ b/tests/test_subodes.py
@@ -143,7 +143,7 @@ def test_codegen_component_ode_monitor(z_ode_codegen):
 
 
 def test_codegen_component_ode_fe(z_ode_codegen):
-    assert z_ode_codegen.scheme("forward_euler") == (
+    assert z_ode_codegen.scheme(gotranx.get_scheme("forward_euler")) == (
         "def forward_euler(states, t, dt, parameters, missing_variables):"
         "\n"
         "\n    # Assign states"


### PR DESCRIPTION
Pass in a function to generate the numerical schemes rather than a name. So now if we have
```python
import gotranx

ode = gotranx.load("file.ode")
codegen = gotranx.codegen.PythonCodeGenerator(ode)
```
Then instead of doing
```python
code = codegen.scheme(name="forward_explicit_euler")
```
we now do
```python
code = codegen.scheme(f=gotranx.get_scheme("forward_explicit_euler"))
```
This way the user can now create their own custom function as pass in instead.