### PR TITLE
Create different commands and add config

### DIFF
--- a/.cspell_dict.txt
+++ b/.cspell_dict.txt
@@ -61,6 +61,7 @@ ptds
 ptsd
 pycode
 pyplot
+pyproject
 Radau
 Rdmm
 relop

--- a/_toc.yml
+++ b/_toc.yml
@@ -13,6 +13,7 @@ parts:
     chapters:
     - file: "examples/new-language/main.py"
     - file: "docs/new_scheme"
+    - file: "docs/config"
     - file: "examples/split-ode/main.py"
     - file: "examples/compile-c-extension/main.py"
     - file: "docs/vectorized_computations"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -159,7 +159,7 @@ V_index = model.state_index("V")
 V = [y[V_index]]
 
 for ti in t[1:]:
-    y = model.forward_generalized_rush_larsen(y, ti, dt, p)
+    y = model.generalized_rush_larsen(y, ti, dt, p)
     V.append(y[V_index])
 
 plt.plot(t, V)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,7 +30,7 @@ The `cellml` format is a format similar to XML.
 
 We will now convert the `.cellml` file to a `.ode` file using the following command
 ```{code-cell} shell
-!python3 -m gotranx convert noble_1962.cellml --to .ode
+!python3 -m gotranx cellml2ode noble_1962.cellml
 ```
 This `cellml` converter is actually based on a different project called [`myokit`](https://github.com/myokit/myokit). `gotranx` allows for converting to and from `myokit` models and `myokit` allows for conversion to and from `cellml`.
 
@@ -51,25 +51,25 @@ Now that we have a `.ode` file we can use this to generate source code in python
 `````{tab-set}
 ````{tab-item} Python
 ```shell
-python3 -m gotranx convert noble_1962.ode --to .py
+python3 -m gotranx ode2py noble_1962.ode
 ```
 ````
 
 ````{tab-item} C
 Either to at `.c` file
 ```shell
-python3 -m gotranx convert noble_1962.ode --to .c
+python3 -m gotranx ode2py noble_1962.ode --to .c
 ```
 or to a `.h` file
 ```shell
-python3 -m gotranx convert noble_1962.ode --to .h
+python3 -m gotranx ode2py noble_1962.ode --to .h
 ```
 ````
 `````
 
 Let us generate some code in python
 ```{code-cell} shell
-!python3 -m gotranx convert noble_1962.ode --to .py
+!python3 -m gotranx ode2py noble_1962.ode
 ```
 
 Now let us take a look at the generated code
@@ -134,13 +134,13 @@ In the example above we only generated the right hand side (function `rhs`) whic
 
 We can generate this scheme using the following command
 ```{code-cell} shell
-!python3 -m gotranx convert noble_1962.ode --to .py --scheme forward_generalized_rush_larsen -o noble_1962_grl.py
+!python3 -m gotranx ode2py noble_1962.ode --scheme generalized_rush_larsen -o noble_1962_grl.py
 ```
 Here we also specify that the code should be saved to a new file called `noble_1962_grl.py` (just to not conflict with the existing file)
 
 The file `noble_1962_grl.py` will now also contain the function
 ```python
-def forward_generalized_rush_larsen(states, t, dt, parameters): ...
+def generalized_rush_larsen(states, t, dt, parameters): ...
 ```
 
 and we can now solve the problem with the following program

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,89 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# Configuration
+
+Using the command line you can see the available options using the `--help` flag. For example
+```{code-cell} shell
+!gotranx --help
+```
+or more specifically
+```{code-cell} shell
+!gotranx ode2py --help
+```
+
+## Specify configurations in `pyproject.toml`
+
+It is also possible to specify the options in your `pyproject.toml`, e.g
+```toml
+# pyproject.toml
+
+[tool.gotranx]
+verbose = true
+delta = 1e-6
+scheme = [
+    "explicit_euler",
+    "generalized_rush_larsen",
+    "hybrid_rush_larsen",
+]
+stiff_states = [
+    "m",
+    "h",
+    "j",
+]
+
+[tool.gotranx.python]
+format = "ruff"
+
+[tool.gotranx.c]
+format = "clang-format"
+```
+
+This will override any arguments passed from the command line. If you want to specify another configuration file, you can also pass the `--config` (or `-c`) flag where you specify a configuration file, e.g
+
+```shell
+gotranx ode2py file.ode -c folder/pyproject.toml
+```
+
+## Options
+
+
+### General options (under `tool.gotranx`)
+
+- `verbose` (boolean, default: `false`): If True display more logging
+- `scheme` (list[str], default: []): Which schemes to include, see
+```{code-cell} shell
+!gotranx list-schemes
+```
+- `delta` (float, default: 1e-8): Tolerance for zero division check in Rush-Larsen schemes
+- `stiff_states`: (list[str], default: []): List of states where to apply the Rush-Larsen scheme for Hybrid Rush Larsen
+
+### Python specific options (under `tool.gotranx.python`)
+
+- `format` (str, default: `black`). Formatter to use for the python code
+
+```{code-cell} python
+import gotranx
+
+print(gotranx.codegen.PythonFormat._member_names_)
+```
+
+### C specific options (under `tool.gotranx.c`)
+
+- `format` (str, default: `clang-format`). Formatter to use for the C code
+
+```{code-cell} python
+import gotranx
+
+print(gotranx.codegen.CFormat._member_names_)
+```
+- `to` (str, default `.h`). Whether to save the C code to a `.c` or `.h` file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,7 @@ test = [
 
 [project.scripts]
 gotranx = "gotranx.cli:app"
-ode2py = "gotranx.cli:ode2py"
-ode2c = "gotranx.cli:ode2c"
-cellml2ode = "gotranx.cli:cellml2ode"
+
 
 [tool.setuptools]
 include-package-data = true
@@ -166,15 +164,3 @@ current_version = "1.0.0"
 filename = "pyproject.toml"
 search = 'version = "{current_version}"'
 replace = 'version = "{new_version}"'
-
-[tool.gotranx]
-verbose = true
-delta = 1e-6
-scheme = [
-    "explicit_euler",
-    "generalized_rush_larsen",
-]
-
-[tool.gotranx.formatter]
-c = "clang-format"
-python = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.8"
 dependencies = [
     "attrs",
     "clang-format-docs",
-    "ruff",
+    "black",
     "lark",
     "pint",
     "rich-click",
@@ -63,6 +63,9 @@ test = [
 
 [project.scripts]
 gotranx = "gotranx.cli:app"
+ode2py = "gotranx.cli:ode2py"
+ode2c = "gotranx.cli:ode2c"
+cellml2ode = "gotranx.cli:cellml2ode"
 
 [tool.setuptools]
 include-package-data = true
@@ -162,3 +165,10 @@ current_version = "1.0.0"
 filename = "pyproject.toml"
 search = 'version = "{current_version}"'
 replace = 'version = "{new_version}"'
+
+[tool.gotranx]
+verbose = true
+
+[tool.gotranx.formatter]
+c = "clang-format"
+python = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,6 @@ test = "pytest"
 addopts = "--cov=gotranx --cov-report html --cov-report xml --cov-report term-missing -v"
 testpaths = ["tests"]
 
-[tool.isort]
-profile = "black"
 
 [tool.mypy]
 files = ["src/gotranx", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.8"
 dependencies = [
     "attrs",
     "clang-format-docs",
-    "black",
+    "ruff",
     "lark",
     "pint",
     "rich-click",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,11 @@ replace = 'version = "{new_version}"'
 
 [tool.gotranx]
 verbose = true
+delta = 1e-6
+scheme = [
+    "explicit_euler",
+    "generalized_rush_larsen",
+]
 
 [tool.gotranx.formatter]
 c = "clang-format"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "sympy",
     "typer",
     "myokit",
+    "toml; python_version < '3.11'",
     'graphlib-backport;python_version < "3.9"',
     'typing_extensions;python_version < "3.9"',
 ]

--- a/src/gotranx/_enum.py
+++ b/src/gotranx/_enum.py
@@ -1,4 +1,5 @@
 from enum import Enum, EnumMeta
+
 # https://stackoverflow.com/questions/62299740/how-do-i-detect-and-invoke-a-function-when-a-python-enum-member-is-accessed
 
 

--- a/src/gotranx/cli/__init__.py
+++ b/src/gotranx/cli/__init__.py
@@ -107,7 +107,7 @@ def convert(
     ] = None,
     stiff_states: Annotated[
         typing.Optional[typing.List[str]],
-        typer.Option(help="Stiff states for the hybrid rush larsen scheme"),
+        typer.Option("-s", "--stiff-states", help="Stiff states for the hybrid rush larsen scheme"),
     ] = None,
     delta: float = typer.Option(
         1e-8,
@@ -267,16 +267,18 @@ def ode2py(
     ] = [],
     stiff_states: Annotated[
         typing.List[str],
-        typer.Option(help="Stiff states for the hybrid rush larsen scheme"),
+        typer.Option("-s", "--stiff-states", help="Stiff states for the hybrid rush larsen scheme"),
     ] = [],
     delta: float = typer.Option(
         1e-8,
         help="Delta value for the rush larsen schemes",
     ),
-    format: Annotated[
-        PythonFormat,
-        typer.Option(help="Formatter for the output code"),
-    ] = PythonFormat.black,
+    format: PythonFormat = typer.Option(
+        PythonFormat.black,
+        "--format",
+        "-f",
+        help="Formatter for the output code",
+    ),
 ):
     if fname is None:
         return typer.echo("No file specified")
@@ -287,7 +289,7 @@ def ode2py(
     stiff_states = config_data.get("stiff_states", stiff_states)
     scheme = config_data.get("scheme", scheme)
     scheme = utils.validate_scheme(scheme)
-    format = PythonFormat[config_data.get("format", {}).get("python", format)]
+    format = PythonFormat(config_data.get("format", {}).get("python", format))
 
     gotran2py.main(
         fname=fname,
@@ -313,7 +315,6 @@ def ode2c(
         resolve_path=True,
     ),
     to: str = typer.Option(
-        "",
         "--to",
         help="Generate code to another programming language",
     ),
@@ -360,7 +361,7 @@ def ode2c(
     ] = [],
     stiff_states: Annotated[
         typing.List[str],
-        typer.Option(help="Stiff states for the hybrid rush larsen scheme"),
+        typer.Option("-s", "--stiff-states", help="Stiff states for the hybrid rush larsen scheme"),
     ] = [],
     delta: float = typer.Option(
         1e-8,
@@ -382,7 +383,7 @@ def ode2c(
     stiff_states = config_data.get("stiff_states", stiff_states)
     scheme = config_data.get("scheme", scheme)
     scheme = utils.validate_scheme(scheme)
-    format = CFormat[config_data.get("format", {}).get("c", format)]
+    format = CFormat(config_data.get("format", {}).get("c", format))
 
     gotran2c.main(
         fname=fname,

--- a/src/gotranx/cli/__init__.py
+++ b/src/gotranx/cli/__init__.py
@@ -1,5 +1,6 @@
 import typing
 from pathlib import Path
+import warnings
 
 try:
     from typing import Annotated
@@ -9,7 +10,8 @@ except ImportError:
 import typer
 
 from ..schemes import Scheme
-from . import gotran2c, gotran2py, cellml2ode
+from ..codegen import PythonFormatter, CFormatter
+from . import gotran2c, gotran2py
 
 app = typer.Typer()
 
@@ -49,6 +51,48 @@ def main(
         help="Show license",
     ),
 ): ...
+
+
+def find_pyproject_toml_config() -> Path | None:
+    """Find the pyproject.toml file."""
+    from black.files import find_pyproject_toml
+
+    path = find_pyproject_toml((str(Path.cwd()),))
+    if path is None:
+        return None
+    return Path(path)
+
+
+def read_config(path: Path | None) -> dict[str, typing.Any]:
+    """Read the configuration file."""
+
+    # If no path is given, try to find the pyproject.toml file
+    if path is None:
+        path = find_pyproject_toml_config()
+
+    # Return empty dict if no path is found
+    if path is None:
+        return {}
+
+    # Try to read the configuration file
+    try:
+        # First try to use tomllib which is part of stdlib
+        import tomllib as toml
+    except ImportError:
+        # If tomllib is not available, try to use toml
+        try:
+            import toml  # type: ignore
+        except ImportError:
+            typer.echo("Please install 'tomllib' or 'toml' to read configuration files")
+            return {}
+
+    try:
+        config = toml.loads(Path(path).read_text())
+    except Exception:
+        typer.echo(f"Could not read configuration file {path}")
+        return {}
+    else:
+        return config.get("tool", {}).get("gotranx", {})
 
 
 @app.command()
@@ -111,6 +155,12 @@ def convert(
         help="Delta value for the rush larsen schemes",
     ),
 ):
+    warnings.warn(
+        "convert command is deprecated, use ode2c, ode2py or cellml2ode instead",
+        DeprecationWarning,
+        stacklevel=1,
+    )
+
     if fname is None:
         return typer.echo("No file specified")
 
@@ -145,7 +195,237 @@ def convert(
         )
 
     if to in {".ode"}:
-        cellml2ode.main(fname=fname, outname=outname, verbose=verbose)
+        from .cellml2ode import main as _main
+
+        _main(fname=fname, outname=outname, verbose=verbose)
+
+
+@app.command()
+def cellml2ode(
+    fname: typing.Optional[Path] = typer.Argument(
+        None,
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        writable=False,
+        readable=True,
+        resolve_path=True,
+    ),
+    outname: typing.Optional[str] = typer.Option(
+        None,
+        "-o",
+        "--outname",
+        help="Output name",
+    ),
+    version: bool = typer.Option(
+        None,
+        "--version",
+        callback=version_callback,
+        is_eager=True,
+        help="Show version",
+    ),
+    license: bool = typer.Option(
+        None,
+        "--license",
+        callback=license_callback,
+        is_eager=True,
+        help="Show license",
+    ),
+    config: typing.Optional[Path] = typer.Option(
+        None,
+        "--config",
+        help="Read configuration options from a configuration file",
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Verbose output",
+    ),
+):
+    if fname is None:
+        return typer.echo("No file specified")
+
+    # config_data = read_config(config)
+    from .cellml2ode import main as _main
+
+    _main(fname=fname, outname=outname, verbose=verbose)
+
+
+@app.command()
+def ode2py(
+    fname: typing.Optional[Path] = typer.Argument(
+        None,
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        writable=False,
+        readable=True,
+        resolve_path=True,
+    ),
+    to: str = typer.Option(
+        "",
+        "--to",
+        help="Generate code to another programming language",
+    ),
+    outname: typing.Optional[str] = typer.Option(
+        None,
+        "-o",
+        "--outname",
+        help="Output name",
+    ),
+    remove_unused: bool = typer.Option(
+        False,
+        "--remove-unused",
+        help="Remove unused variables",
+    ),
+    version: bool = typer.Option(
+        None,
+        "--version",
+        callback=version_callback,
+        is_eager=True,
+        help="Show version",
+    ),
+    license: bool = typer.Option(
+        None,
+        "--license",
+        callback=license_callback,
+        is_eager=True,
+        help="Show license",
+    ),
+    config: typing.Optional[Path] = typer.Option(
+        None,
+        "--config",
+        help="Read configuration options from a configuration file",
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Verbose output",
+    ),
+    scheme: Annotated[
+        typing.Optional[typing.List[Scheme]],
+        typer.Option(help="Numerical scheme for solving the ODE"),
+    ] = None,
+    stiff_states: Annotated[
+        typing.Optional[typing.List[str]],
+        typer.Option(help="Stiff states for the hybrid rush larsen scheme"),
+    ] = None,
+    delta: float = typer.Option(
+        1e-8,
+        help="Delta value for the rush larsen schemes",
+    ),
+    formatter: PythonFormatter = typer.Option(
+        PythonFormatter.black,
+        "--formatter",
+        "-f",
+        help="Formatter for the output code",
+    ),
+):
+    if fname is None:
+        return typer.echo("No file specified")
+
+    # config_data = read_config(config)
+
+    gotran2py.main(
+        fname=fname,
+        suffix=to,
+        outname=outname,
+        scheme=scheme,
+        remove_unused=remove_unused,
+        verbose=verbose,
+        stiff_states=stiff_states,
+        delta=delta,
+    )
+
+
+@app.command()
+def ode2c(
+    fname: typing.Optional[Path] = typer.Argument(
+        None,
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        writable=False,
+        readable=True,
+        resolve_path=True,
+    ),
+    to: str = typer.Option(
+        "",
+        "--to",
+        help="Generate code to another programming language",
+    ),
+    outname: typing.Optional[str] = typer.Option(
+        None,
+        "-o",
+        "--outname",
+        help="Output name",
+    ),
+    remove_unused: bool = typer.Option(
+        False,
+        "--remove-unused",
+        help="Remove unused variables",
+    ),
+    version: bool = typer.Option(
+        None,
+        "--version",
+        callback=version_callback,
+        is_eager=True,
+        help="Show version",
+    ),
+    license: bool = typer.Option(
+        None,
+        "--license",
+        callback=license_callback,
+        is_eager=True,
+        help="Show license",
+    ),
+    config: typing.Optional[Path] = typer.Option(
+        None,
+        "--config",
+        help="Read configuration options from a configuration file",
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Verbose output",
+    ),
+    scheme: Annotated[
+        typing.Optional[typing.List[Scheme]],
+        typer.Option(help="Numerical scheme for solving the ODE"),
+    ] = None,
+    stiff_states: Annotated[
+        typing.Optional[typing.List[str]],
+        typer.Option(help="Stiff states for the hybrid rush larsen scheme"),
+    ] = None,
+    delta: float = typer.Option(
+        1e-8,
+        help="Delta value for the rush larsen schemes",
+    ),
+    formatter: CFormatter = typer.Option(
+        CFormatter.clang_format,
+        "--formatter",
+        "-f",
+        help="Formatter for the output code",
+    ),
+):
+    if fname is None:
+        return typer.echo("No file specified")
+
+    # config_data = read_config(config)
+
+    gotran2c.main(
+        fname=fname,
+        suffix=to,
+        outname=outname,
+        scheme=scheme,
+        remove_unused=remove_unused,
+        verbose=verbose,
+        stiff_states=stiff_states,
+        delta=delta,
+    )
 
 
 @app.command()

--- a/src/gotranx/cli/__init__.py
+++ b/src/gotranx/cli/__init__.py
@@ -289,7 +289,8 @@ def ode2py(
     stiff_states = config_data.get("stiff_states", stiff_states)
     scheme = config_data.get("scheme", scheme)
     scheme = utils.validate_scheme(scheme)
-    format = PythonFormat(config_data.get("format", {}).get("python", format))
+    py_config = config_data.get("python", {})
+    format = PythonFormat(py_config.get("format", format))
 
     gotran2py.main(
         fname=fname,
@@ -315,6 +316,7 @@ def ode2c(
         resolve_path=True,
     ),
     to: str = typer.Option(
+        ".h",
         "--to",
         help="Generate code to another programming language",
     ),
@@ -383,7 +385,9 @@ def ode2c(
     stiff_states = config_data.get("stiff_states", stiff_states)
     scheme = config_data.get("scheme", scheme)
     scheme = utils.validate_scheme(scheme)
-    format = CFormat(config_data.get("format", {}).get("c", format))
+    c_config = config_data.get("c", {})
+    to = c_config.get("to", to)
+    format = CFormat(c_config.get("format", format))
 
     gotran2c.main(
         fname=fname,

--- a/src/gotranx/cli/__init__.py
+++ b/src/gotranx/cli/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import typing
 from pathlib import Path
 import warnings
@@ -52,48 +51,6 @@ def main(
         help="Show license",
     ),
 ): ...
-
-
-def find_pyproject_toml_config() -> Path | None:
-    """Find the pyproject.toml file."""
-    from black.files import find_pyproject_toml
-
-    path = find_pyproject_toml((str(Path.cwd()),))
-    if path is None:
-        return None
-    return Path(path)
-
-
-def read_config(path: Path | None) -> dict[str, typing.Any]:
-    """Read the configuration file."""
-
-    # If no path is given, try to find the pyproject.toml file
-    if path is None:
-        path = find_pyproject_toml_config()
-
-    # Return empty dict if no path is found
-    if path is None:
-        return {}
-
-    # Try to read the configuration file
-    try:
-        # First try to use tomllib which is part of stdlib
-        import tomllib as toml
-    except ImportError:
-        # If tomllib is not available, try to use toml
-        try:
-            import toml  # type: ignore
-        except ImportError:
-            typer.echo("Please install 'tomllib' or 'toml' to read configuration files")
-            return {}
-
-    try:
-        config = toml.loads(Path(path).read_text())
-    except Exception:
-        typer.echo(f"Could not read configuration file {path}")
-        return {}
-    else:
-        return config.get("tool", {}).get("gotranx", {})
 
 
 @app.command()

--- a/src/gotranx/cli/__init__.py
+++ b/src/gotranx/cli/__init__.py
@@ -12,6 +12,7 @@ import typer
 from ..schemes import Scheme
 from ..codegen import PythonFormatter, CFormatter
 from . import gotran2c, gotran2py
+from .utils import read_config
 
 app = typer.Typer()
 
@@ -204,7 +205,9 @@ def cellml2ode(
     if fname is None:
         return typer.echo("No file specified")
 
-    # config_data = read_config(config)
+    config_data = read_config(config)
+    verbose = config_data.get("verbose", verbose)
+
     from .cellml2ode import main as _main
 
     _main(fname=fname, outname=outname, verbose=verbose)
@@ -220,11 +223,6 @@ def ode2py(
         writable=False,
         readable=True,
         resolve_path=True,
-    ),
-    to: str = typer.Option(
-        "",
-        "--to",
-        help="Generate code to another programming language",
     ),
     outname: typing.Optional[str] = typer.Option(
         None,
@@ -284,11 +282,12 @@ def ode2py(
     if fname is None:
         return typer.echo("No file specified")
 
-    # config_data = read_config(config)
+    config_data = read_config(config)
+    verbose = config_data.get("verbose", verbose)
+    formatter = config_data.get("formatter", formatter)
 
     gotran2py.main(
         fname=fname,
-        suffix=to,
         outname=outname,
         scheme=scheme,
         remove_unused=remove_unused,

--- a/src/gotranx/cli/__init__.py
+++ b/src/gotranx/cli/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import typing
 from pathlib import Path
 import warnings

--- a/src/gotranx/cli/gotran2c.py
+++ b/src/gotranx/cli/gotran2c.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import logging
 import structlog
 
-from ..codegen.c import CCodeGenerator
+from ..codegen.c import CCodeGenerator, Format
 from ..load import load_ode
 from ..schemes import Scheme
 from ..ode import ODE
@@ -16,7 +16,7 @@ logger = structlog.get_logger()
 def get_code(
     ode: ODE,
     scheme: list[Scheme] | None = None,
-    apply_clang_format: bool = True,
+    format: Format = Format.clang_format,
     remove_unused: bool = False,
     missing_values: dict[str, int] | None = None,
     delta: float = 1e-8,
@@ -30,8 +30,8 @@ def get_code(
         The ODE
     scheme : list[Scheme] | None, optional
         Optional numerical scheme, by default None
-    apply_clang_format : bool, optional
-        Apply clang formatter, by default True
+    format : gotranx.codegen.python.Format, optional
+        The formatter, by default gotranx.codegen.python.Format.black
     remove_unused : bool, optional
         Remove unused variables, by default False
     missing_values : dict[str, int] | None, optional
@@ -47,9 +47,7 @@ def get_code(
     str
         The C code
     """
-    codegen = CCodeGenerator(
-        ode, remove_unused=remove_unused, apply_clang_format=apply_clang_format
-    )
+    codegen = CCodeGenerator(ode, remove_unused=remove_unused, format=format)
 
     if missing_values is not None:
         _missing_values = codegen.missing_values(missing_values)
@@ -86,7 +84,7 @@ def main(
     outname: str | None = None,
     scheme: list[Scheme] | None = None,
     remove_unused: bool = False,
-    apply_clang_format: bool = True,
+    format: Format = Format.clang_format,
     verbose: bool = False,
     missing_values: dict[str, int] | None = None,
     delta: float = 1e-8,
@@ -100,7 +98,7 @@ def main(
     code = get_code(
         ode,
         scheme=scheme,
-        apply_clang_format=apply_clang_format,
+        format=format,
         remove_unused=remove_unused,
         missing_values=missing_values,
         delta=delta,

--- a/src/gotranx/cli/gotran2py.py
+++ b/src/gotranx/cli/gotran2py.py
@@ -16,7 +16,7 @@ logger = structlog.get_logger()
 def get_code(
     ode: ODE,
     scheme: list[Scheme] | None = None,
-    apply_black: bool = True,
+    format: bool = True,
     remove_unused: bool = False,
     missing_values: dict[str, int] | None = None,
     delta: float = 1e-8,
@@ -30,8 +30,8 @@ def get_code(
         The ODE
     scheme : list[Scheme] | None, optional
         Optional numerical scheme, by default None
-    apply_black : bool, optional
-        Apply black formatter, by default True
+    format : bool, optional
+        Apply ruff / black formatter, by default True
     remove_unused : bool, optional
         Remove unused variables, by default False
     missing_values : dict[str, int] | None, optional
@@ -49,7 +49,7 @@ def get_code(
     """
     codegen = PythonCodeGenerator(
         ode,
-        apply_black=False,
+        format=False,
         remove_unused=remove_unused,
     )
     formatter = get_formatter()
@@ -76,7 +76,7 @@ def get_code(
         stiff_states=stiff_states,
     )
     code = codegen._format("\n".join(comp))
-    if apply_black:
+    if format:
         code = formatter(code)
     return code
 
@@ -85,7 +85,7 @@ def main(
     fname: Path,
     suffix: str = ".py",
     outname: str | None = None,
-    apply_black: bool = True,
+    format: bool = True,
     scheme: list[Scheme] | None = None,
     remove_unused: bool = False,
     verbose: bool = True,
@@ -101,7 +101,7 @@ def main(
     code = get_code(
         ode,
         scheme=scheme,
-        apply_black=apply_black,
+        format=format,
         remove_unused=remove_unused,
         delta=delta,
     )

--- a/src/gotranx/cli/gotran2py.py
+++ b/src/gotranx/cli/gotran2py.py
@@ -30,8 +30,8 @@ def get_code(
         The ODE
     scheme : list[Scheme] | None, optional
         Optional numerical scheme, by default None
-    format : Format, optional
-        The formatter, by default Format.black
+    format : gotranx.codegen.python.Format, optional
+        The formatter, by default gotranx.codegen.python.Format.black
     remove_unused : bool, optional
         Remove unused variables, by default False
     missing_values : dict[str, int] | None, optional
@@ -85,7 +85,6 @@ def get_code(
 
 def main(
     fname: Path,
-    suffix: str = ".py",
     outname: str | None = None,
     format: Format = Format.black,
     scheme: list[Scheme] | None = None,
@@ -93,6 +92,7 @@ def main(
     verbose: bool = True,
     stiff_states: list[str] | None = None,
     delta: float = 1e-8,
+    suffix: str = ".py",
 ) -> None:
     loglevel = logging.DEBUG if verbose else logging.INFO
     structlog.configure(

--- a/src/gotranx/cli/gotran2py.py
+++ b/src/gotranx/cli/gotran2py.py
@@ -79,6 +79,7 @@ def get_code(
 
     if format != Format.none:
         # Run the formatter only once
+        logger.debug("Applying formatter", format=format)
         code = formatter(code)
     return code
 

--- a/src/gotranx/cli/gotran2py.py
+++ b/src/gotranx/cli/gotran2py.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import logging
 import structlog
 
-from ..codegen.python import PythonCodeGenerator
+from ..codegen.python import PythonCodeGenerator, get_formatter
 from ..load import load_ode
 from ..schemes import Scheme
 from ..ode import ODE
@@ -49,9 +49,10 @@ def get_code(
     """
     codegen = PythonCodeGenerator(
         ode,
-        apply_black=apply_black,
+        apply_black=False,
         remove_unused=remove_unused,
     )
+    formatter = get_formatter()
     if missing_values is not None:
         _missing_values = codegen.missing_values(missing_values)
     else:
@@ -74,7 +75,10 @@ def get_code(
         delta=delta,
         stiff_states=stiff_states,
     )
-    return codegen._format("\n".join(comp))
+    code = codegen._format("\n".join(comp))
+    if apply_black:
+        code = formatter(code)
+    return code
 
 
 def main(

--- a/src/gotranx/cli/utils.py
+++ b/src/gotranx/cli/utils.py
@@ -67,3 +67,13 @@ def read_config(path: Path | None) -> dict[str, Any]:
         return {}
     else:
         return config.get("tool", {}).get("gotranx", {})
+
+
+def validate_scheme(scheme: list[Scheme] | list[str]) -> list[Scheme]:
+    lst = []
+    for s in scheme:
+        if isinstance(s, str):
+            lst.append(Scheme(s))
+        else:
+            lst.append(s)
+    return lst

--- a/src/gotranx/codegen/__init__.py
+++ b/src/gotranx/codegen/__init__.py
@@ -3,8 +3,8 @@ from . import c
 from . import python
 from . import ode
 
-from .c import CCodeGenerator, GotranCCodePrinter
-from .python import PythonCodeGenerator, GotranPythonCodePrinter
+from .c import CCodeGenerator, GotranCCodePrinter, Format as CFormatter
+from .python import PythonCodeGenerator, GotranPythonCodePrinter, Format as PythonFormatter
 from .base import CodeGenerator, Func, RHSArgument, SchemeArgument
 from .ode import GotranODECodePrinter, BaseGotranODECodePrinter
 
@@ -23,4 +23,6 @@ __all__ = [
     "GotranODECodePrinter",
     "BaseGotranODECodePrinter",
     "GotranCCodePrinter",
+    "CFormatter",
+    "PythonFormatter",
 ]

--- a/src/gotranx/codegen/__init__.py
+++ b/src/gotranx/codegen/__init__.py
@@ -3,8 +3,8 @@ from . import c
 from . import python
 from . import ode
 
-from .c import CCodeGenerator, GotranCCodePrinter, Format as CFormatter
-from .python import PythonCodeGenerator, GotranPythonCodePrinter, Format as PythonFormatter
+from .c import CCodeGenerator, GotranCCodePrinter, Format as CFormat
+from .python import PythonCodeGenerator, GotranPythonCodePrinter, Format as PythonFormat
 from .base import CodeGenerator, Func, RHSArgument, SchemeArgument
 from .ode import GotranODECodePrinter, BaseGotranODECodePrinter
 
@@ -23,6 +23,6 @@ __all__ = [
     "GotranODECodePrinter",
     "BaseGotranODECodePrinter",
     "GotranCCodePrinter",
-    "CFormatter",
-    "PythonFormatter",
+    "CFormat",
+    "PythonFormat",
 ]

--- a/src/gotranx/codegen/base.py
+++ b/src/gotranx/codegen/base.py
@@ -7,11 +7,14 @@ from enum import Enum
 import sympy
 from sympy.codegen.ast import Assignment
 from sympy.printing.codeprinter import CodePrinter
+import structlog
 
 from .. import templates
 from ..ode import ODE
 from .. import atoms
 from .. import schemes
+
+logger = structlog.get_logger()
 
 
 class Func(typing.NamedTuple):
@@ -132,7 +135,7 @@ class CodeGenerator(abc.ABC):
             formatted_code = self._formatter(code)
         except Exception:
             # FIXME: handle this
-            print("An exception was raised")
+            logger.error("An exception was raised")
             formatted_code = code
 
         return formatted_code

--- a/src/gotranx/codegen/c.py
+++ b/src/gotranx/codegen/c.py
@@ -9,7 +9,7 @@ from .. import templates
 from .base import CodeGenerator, Func, RHSArgument, SchemeArgument
 
 
-class Format(enum.Enum):
+class Format(str, enum.Enum):
     clang_format = "clang-format"
     none = "none"
 

--- a/src/gotranx/codegen/c.py
+++ b/src/gotranx/codegen/c.py
@@ -58,18 +58,22 @@ class CCodeGenerator(CodeGenerator):
     variable_prefix = "const double "
 
     def __init__(
-        self, ode: ODE, apply_clang_format: bool = True, remove_unused: bool = False
+        self, ode: ODE, format: Format = Format.clang_format, remove_unused: bool = False
     ) -> None:
         super().__init__(ode, remove_unused=remove_unused)
         self._printer = GotranCCodePrinter()
 
-        if apply_clang_format:
+        if format == Format.clang_format:
             try:
                 import clang_format_docs
             except ImportError:
                 print("Cannot apply clang-format, please install 'clang-format-docs'")
             else:
                 setattr(self, "_formatter", clang_format_docs.clang_format_str)
+        elif format == Format.none:
+            setattr(self, "_formatter", lambda x: x)
+        else:
+            raise ValueError(f"Unknown format {format}")
 
     @property
     def printer(self):

--- a/src/gotranx/codegen/c.py
+++ b/src/gotranx/codegen/c.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import enum
 from sympy.printing.c import C99CodePrinter
 from sympy.codegen.ast import Assignment
 import sympy
@@ -6,6 +7,11 @@ import sympy
 from ..ode import ODE
 from .. import templates
 from .base import CodeGenerator, Func, RHSArgument, SchemeArgument
+
+
+class Format(enum.Enum):
+    clang_format = "clang-format"
+    none = "none"
 
 
 def bool_to_int(expr: str) -> str:

--- a/src/gotranx/codegen/python.py
+++ b/src/gotranx/codegen/python.py
@@ -16,7 +16,7 @@ from .base import CodeGenerator, Func, RHSArgument, SchemeArgument, _print_Piece
 logger = structlog.get_logger()
 
 
-class Format(Enum):
+class Format(str, Enum):
     black = "black"
     ruff = "ruff"
     none = "none"

--- a/src/gotranx/codegen/python.py
+++ b/src/gotranx/codegen/python.py
@@ -149,8 +149,7 @@ class PythonCodeGenerator(CodeGenerator):
 
         self._printer = GotranPythonCodePrinter()
 
-        if format:
-            setattr(self, "_formatter", get_formatter(format=format))
+        setattr(self, "_formatter", get_formatter(format=format))
 
     @property
     def printer(self):

--- a/src/gotranx/codegen/python.py
+++ b/src/gotranx/codegen/python.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import typing
 from sympy.printing.pycode import PythonCodePrinter
 
 # from sympy.printing.numpy import NumPyPrinter
@@ -100,7 +101,7 @@ class GotranPythonCodePrinter(PythonCodePrinter):
         return value
 
 
-def get_formatter():
+def get_formatter() -> typing.Callable[[str], str]:
     # First try ruff
     try:
         import ruff.__main__
@@ -112,7 +113,7 @@ def get_formatter():
             import black
         except ImportError:
             logger.warning("Cannot apply black, please install 'black'")
-            return None
+            return lambda x: x
         else:
             # TODO: add options for black in Mode
             return partial(black.format_str, mode=black.Mode())
@@ -126,12 +127,12 @@ def get_formatter():
 
 
 class PythonCodeGenerator(CodeGenerator):
-    def __init__(self, ode: ODE, apply_black: bool = True, *args, **kwargs) -> None:
+    def __init__(self, ode: ODE, format: bool = True, *args, **kwargs) -> None:
         super().__init__(ode, *args, **kwargs)
 
         self._printer = GotranPythonCodePrinter()
 
-        if apply_black:
+        if format:
             setattr(self, "_formatter", get_formatter())
 
     @property

--- a/src/gotranx/schemes.py
+++ b/src/gotranx/schemes.py
@@ -215,9 +215,9 @@ def hybrid_rush_larsen(
         A list of equations as strings
 
     """
-    logger.debug("Generating hybrid Rush-Larsen scheme")
     if stiff_states is None:
         stiff_states = []
+    logger.debug("Generating hybrid Rush-Larsen scheme", stiff_states=stiff_states)
     stiff_states_set = set(stiff_states) or set()
     found_stiff_states_set = set()
     eqs = []

--- a/src/gotranx/schemes.py
+++ b/src/gotranx/schemes.py
@@ -216,7 +216,10 @@ def hybrid_rush_larsen(
 
     """
     logger.debug("Generating hybrid Rush-Larsen scheme")
-    stiff_states = stiff_states or []
+    if stiff_states is None:
+        stiff_states = []
+    stiff_states_set = set(stiff_states) or set()
+    found_stiff_states_set = set()
     eqs = []
     values = sympy.IndexedBase(name, shape=(len(ode.state_derivatives),))
     i = 0
@@ -227,8 +230,7 @@ def hybrid_rush_larsen(
             continue
 
         expr_diff = x.expr.diff(x.state.symbol)
-        state_is_stiff = x.state.name in stiff_states
-        # breakpoint()
+        state_is_stiff = x.state.name in stiff_states_set
 
         if not state_is_stiff or expr_diff.is_zero:
             # Use forward Euler
@@ -241,6 +243,8 @@ def hybrid_rush_larsen(
             i += 1
             continue
 
+        found_stiff_states_set.add(x.state.name)
+        logger.debug(f"State {x.state.name} is stiff")
         linearized_name = x.name + "_linearized"
         linearized = sympy.Symbol(linearized_name)
         eqs.append(printer(linearized, expr_diff, use_variable_prefix=True))
@@ -263,6 +267,10 @@ def hybrid_rush_larsen(
             )
         )
         i += 1
+    logger.debug(
+        "The following states where marked as stiff but not found in the ODE:",
+        extra=stiff_states_set.difference(found_stiff_states_set),
+    )
     return eqs
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 import gotranx
 import pytest
 from pathlib import Path
@@ -5,6 +6,30 @@ from typer.testing import CliRunner
 
 here = Path(__file__).parent.absolute()
 runner = CliRunner(mix_stderr=False)
+
+
+@pytest.fixture(scope="session")
+def config_file(tmp_path_factory):
+    text = dedent(
+        """
+        [tool.gotranx]
+        scheme = ["hybrid_rush_larsen"]
+        stiff_states = ["x", "y"]
+        verbose = true
+        delta = 1e-3
+
+        [tool.gotranx.python]
+        format = "ruff"
+
+        [tool.gotranx.c]
+        format = "none"
+        to = ".c"
+        """
+    )
+    fname = tmp_path_factory.mktemp("data") / "pyproject.toml"
+    fname.write_text(text)
+    yield fname
+    fname.unlink()
 
 
 @pytest.fixture(scope="module")
@@ -132,17 +157,25 @@ def test_cellml2ode():
     out_odefile.unlink()
 
 
-def test_gotran2py(odefile, all_schemes):
+@pytest.mark.parametrize("format", gotranx.codegen.PythonFormat)
+def test_gotran2py(format, odefile, all_schemes):
     outfile = odefile.with_suffix(".py")
 
     stiff_states = ["-s", "x", "-s", "y", "-s", "w"]
 
     result = runner.invoke(
-        gotranx.cli.app, ["ode2py", str(odefile), "-o", str(outfile)] + all_schemes + stiff_states
+        gotranx.cli.app,
+        ["ode2py", str(odefile), "-v", "-o", str(outfile), "-f", format.value]
+        + all_schemes
+        + stiff_states,
     )
     assert result.exit_code == 0
     assert "lorentz.py" in result.stdout
     assert "lorentz" in result.stdout
+    if format != gotranx.codegen.PythonFormat.none:
+        assert "Applying formatter" in result.stdout
+        assert format.value in result.stdout
+
     assert outfile.is_file()
 
     code = outfile.read_text()
@@ -158,11 +191,14 @@ def test_gotran2py(odefile, all_schemes):
     outfile.unlink()
 
 
+@pytest.mark.parametrize("format", gotranx.codegen.CFormat)
 @pytest.mark.parametrize("suffix", [".h", ".c"])
-def test_gotran2c(suffix, odefile, all_schemes):
+def test_gotran2c(format, suffix, odefile, all_schemes):
     outfile = odefile.with_suffix(suffix)
     result = runner.invoke(
-        gotranx.cli.app, ["ode2c", str(odefile), "--to", suffix, "-o", str(outfile)] + all_schemes
+        gotranx.cli.app,
+        ["ode2c", str(odefile), "-v", "--to", suffix, "-f", format.value, "-o", str(outfile)]
+        + all_schemes,
     )
     assert result.exit_code == 0
 
@@ -181,3 +217,37 @@ def test_gotran2c(suffix, odefile, all_schemes):
     assert "parameter_index" in code
 
     outfile.with_suffix(suffix).unlink()
+
+
+def test_ode2py_config_file(odefile, config_file):
+    outfile = odefile.with_suffix(".py")
+    result = runner.invoke(
+        gotranx.cli.app,
+        ["ode2py", str(odefile), "-c", str(config_file), "-o", str(outfile)],
+    )
+    assert result.exit_code == 0
+    assert "lorentz.py" in result.stdout
+    assert "lorentz" in result.stdout
+    assert "stiff_states=['x', 'y']" in result.stdout
+    assert "Applying formatter" in result.stdout
+    assert "ruff" in result.stdout
+    assert outfile.is_file()
+    code = outfile.read_text()
+    assert "hybrid_rush_larsen" in code
+    outfile.unlink()
+
+
+def test_ode2c_config_file(odefile, config_file):
+    outfile = odefile.with_suffix(".c")
+    result = runner.invoke(
+        gotranx.cli.app,
+        ["ode2c", str(odefile), "-c", str(config_file), "-o", str(outfile)],
+    )
+    assert result.exit_code == 0
+    assert "lorentz.c" in result.stdout
+    assert "lorentz" in result.stdout
+    assert "stiff_states=['x', 'y']" in result.stdout
+    assert outfile.is_file()
+    code = outfile.read_text()
+    assert "hybrid_rush_larsen" in code
+    outfile.unlink()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,7 +50,7 @@ def test_cli_license():
     assert "MIT" in result.stdout
 
 
-def test_gotran2py(odefile, all_schemes):
+def test_gotran2py_old(odefile, all_schemes):
     outfile = odefile.with_suffix(".py")
 
     result = runner.invoke(
@@ -74,7 +74,7 @@ def test_gotran2py(odefile, all_schemes):
     outfile.unlink()
 
 
-def test_gotran2c(odefile, all_schemes):
+def test_gotran2c_old(odefile, all_schemes):
     outfile = odefile.with_suffix(".h")
     result = runner.invoke(
         gotranx.cli.app, ["convert", str(odefile), "--to", ".h", "-o", str(outfile)] + all_schemes
@@ -98,12 +98,29 @@ def test_gotran2c(odefile, all_schemes):
     outfile.with_suffix(".h").unlink()
 
 
-def test_cellml2ode():
+def test_cellml2ode_old():
     cellmlfile = here / "cellml_files" / "noble_1962.cellml"
     out_odefile = cellmlfile.with_suffix(".ode")
     result = runner.invoke(
         gotranx.cli.app,
         ["convert", str(cellmlfile), "-o", cellmlfile.with_suffix(".ode")],
+    )
+    assert result.exit_code == 0
+
+    assert f"Wrote {out_odefile}" in result.stdout
+    assert out_odefile.is_file()
+    # Check that we can load the file
+    ode = gotranx.load_ode(out_odefile)
+    assert ode is not None
+    out_odefile.unlink()
+
+
+def test_cellml2ode():
+    cellmlfile = here / "cellml_files" / "noble_1962.cellml"
+    out_odefile = cellmlfile.with_suffix(".ode")
+    result = runner.invoke(
+        gotranx.cli.app,
+        ["cellml2ode", str(cellmlfile), "-o", cellmlfile.with_suffix(".ode")],
     )
     assert result.exit_code == 0
 

--- a/tests/test_python_codegen.py
+++ b/tests/test_python_codegen.py
@@ -36,12 +36,12 @@ def codegen(ode) -> PythonCodeGenerator:
 
 
 @pytest.fixture(scope="module")
-def codegen_no_black(ode) -> PythonCodeGenerator:
-    with mock.patch.dict(sys.modules, {"black": None}):
+def codegen_no_format(ode) -> PythonCodeGenerator:
+    with mock.patch.dict(sys.modules, {"black": None, "ruff": None}):
         return PythonCodeGenerator(ode)
 
 
-def test_python_codegen_state_index_no_black(codegen: PythonCodeGenerator):
+def test_python_codegen_state_index_no_format(codegen: PythonCodeGenerator):
     assert codegen.state_index() == (
         'state = {"x": 0, "z": 1, "y": 2}'
         "\n"
@@ -86,8 +86,8 @@ def test_python_codegen_initial_state_values(codegen: PythonCodeGenerator):
     )
 
 
-def test_python_codegen_parameter_index_no_black(codegen_no_black: PythonCodeGenerator):
-    assert codegen_no_black.parameter_index() == (
+def test_python_codegen_parameter_index_no_format(codegen_no_format: PythonCodeGenerator):
+    assert codegen_no_format.parameter_index() == (
         "\nparameter = {'a': 0, 'beta': 1, 'rho': 2, 'sigma': 3}"
         "\n"
         "\n"
@@ -184,7 +184,6 @@ def test_python_codegen_missing_index_is_empty(codegen: PythonCodeGenerator):
 def test_python_codegen_rhs(order: str, arguments: str, codegen: PythonCodeGenerator):
     assert codegen.rhs(order=order) == (
         f"def rhs({arguments}):"
-        "\n"
         "\n    # Assign states"
         "\n    x = states[0]"
         "\n    z = states[1]"
@@ -216,7 +215,6 @@ def test_python_codegen_rhs(order: str, arguments: str, codegen: PythonCodeGener
 def test_python_codegen_forward_explicit_euler(codegen: PythonCodeGenerator):
     assert codegen.scheme(get_scheme("forward_explicit_euler")) == (
         "def forward_explicit_euler(states, t, dt, parameters):"
-        "\n"
         "\n    # Assign states"
         "\n    x = states[0]"
         "\n    z = states[1]"
@@ -248,7 +246,6 @@ def test_python_codegen_forward_explicit_euler(codegen: PythonCodeGenerator):
 def test_python_codegen_forward_generalized_rush_larsen(codegen: PythonCodeGenerator):
     assert codegen.scheme(get_scheme("forward_generalized_rush_larsen")) == (
         "def forward_generalized_rush_larsen(states, t, dt, parameters):"
-        "\n"
         "\n    # Assign states"
         "\n    x = states[0]"
         "\n    z = states[1]"
@@ -299,7 +296,6 @@ def test_python_conditional_expression(parser, trans):
     codegen = PythonCodeGenerator(ode)
     assert codegen.rhs() == (
         "def rhs(t, states, parameters):"
-        "\n"
         "\n    # Assign states"
         "\n    v = states[0]"
         "\n"
@@ -330,7 +326,6 @@ def test_python_exponential_with_power(parser, trans):
 
     assert codegen.rhs() == (
         "def rhs(t, states, parameters):"
-        "\n"
         "\n    # Assign states"
         "\n    v = states[0]"
         "\n"
@@ -352,7 +347,6 @@ def test_python_remove_unused_rhs(ode_unused):
     codegen_orig = PythonCodeGenerator(ode_unused)
     assert codegen_orig.rhs() == (
         "def rhs(t, states, parameters):"
-        "\n"
         "\n    # Assign states"
         "\n    unused_state = states[0]"
         "\n    x = states[1]"
@@ -385,7 +379,6 @@ def test_python_remove_unused_rhs(ode_unused):
     codegen_remove = PythonCodeGenerator(ode_unused, remove_unused=True)
     assert codegen_remove.rhs() == (
         "def rhs(t, states, parameters):"
-        "\n"
         "\n    # Assign states"
         "\n    x = states[1]"
         "\n    y = states[2]"
@@ -417,7 +410,6 @@ def test_python_remove_unused_forward_explicit_euler(ode_unused):
     codegen_orig = PythonCodeGenerator(ode_unused)
     assert codegen_orig.scheme(get_scheme("forward_explicit_euler")) == (
         "def forward_explicit_euler(states, t, dt, parameters):"
-        "\n"
         "\n    # Assign states"
         "\n    unused_state = states[0]"
         "\n    x = states[1]"
@@ -450,7 +442,6 @@ def test_python_remove_unused_forward_explicit_euler(ode_unused):
     codegen_remove = PythonCodeGenerator(ode_unused, remove_unused=True)
     assert codegen_remove.scheme(get_scheme("forward_explicit_euler")) == (
         "def forward_explicit_euler(states, t, dt, parameters):"
-        "\n"
         "\n    # Assign states"
         "\n    unused_state = states[0]"
         "\n    x = states[1]"
@@ -483,7 +474,6 @@ def test_python_remove_unused_forward_generalized_rush_larsen(ode_unused):
     codegen_orig = PythonCodeGenerator(ode_unused)
     assert codegen_orig.scheme(get_scheme("forward_generalized_rush_larsen")) == (
         "def forward_generalized_rush_larsen(states, t, dt, parameters):"
-        "\n"
         "\n    # Assign states"
         "\n    unused_state = states[0]"
         "\n    x = states[1]"
@@ -531,7 +521,6 @@ def test_python_remove_unused_forward_generalized_rush_larsen(ode_unused):
     codegen_remove = PythonCodeGenerator(ode_unused, remove_unused=True)
     assert codegen_remove.scheme(get_scheme("forward_generalized_rush_larsen")) == (
         "def forward_generalized_rush_larsen(states, t, dt, parameters):"
-        "\n"
         "\n    # Assign states"
         "\n    unused_state = states[0]"
         "\n    x = states[1]"
@@ -578,7 +567,6 @@ def test_python_remove_unused_forward_generalized_rush_larsen(ode_unused):
 def test_python_monitored(codegen: PythonCodeGenerator):
     assert codegen.monitor_values() == (
         "def monitor_values(t, states, parameters):"
-        "\n"
         "\n    # Assign states"
         "\n    x = states[0]"
         "\n    z = states[1]"

--- a/tests/test_python_codegen.py
+++ b/tests/test_python_codegen.py
@@ -36,12 +36,12 @@ def codegen(ode) -> PythonCodeGenerator:
 
 
 @pytest.fixture(scope="module")
-def codegen_no_format(ode) -> PythonCodeGenerator:
+def codegen_no_formatter(ode) -> PythonCodeGenerator:
     with mock.patch.dict(sys.modules, {"black": None, "ruff": None}):
         return PythonCodeGenerator(ode)
 
 
-def test_python_codegen_state_index_no_format(codegen: PythonCodeGenerator):
+def test_python_codegen_state_index_no_formatter(codegen: PythonCodeGenerator):
     assert codegen.state_index() == (
         'state = {"x": 0, "z": 1, "y": 2}'
         "\n"
@@ -86,8 +86,8 @@ def test_python_codegen_initial_state_values(codegen: PythonCodeGenerator):
     )
 
 
-def test_python_codegen_parameter_index_no_format(codegen_no_format: PythonCodeGenerator):
-    assert codegen_no_format.parameter_index() == (
+def test_python_codegen_parameter_index_no_formatter(codegen_no_formatter: PythonCodeGenerator):
+    assert codegen_no_formatter.parameter_index() == (
         "\nparameter = {'a': 0, 'beta': 1, 'rho': 2, 'sigma': 3}"
         "\n"
         "\n"
@@ -184,6 +184,7 @@ def test_python_codegen_missing_index_is_empty(codegen: PythonCodeGenerator):
 def test_python_codegen_rhs(order: str, arguments: str, codegen: PythonCodeGenerator):
     assert codegen.rhs(order=order) == (
         f"def rhs({arguments}):"
+        "\n"
         "\n    # Assign states"
         "\n    x = states[0]"
         "\n    z = states[1]"
@@ -215,6 +216,7 @@ def test_python_codegen_rhs(order: str, arguments: str, codegen: PythonCodeGener
 def test_python_codegen_forward_explicit_euler(codegen: PythonCodeGenerator):
     assert codegen.scheme(get_scheme("forward_explicit_euler")) == (
         "def forward_explicit_euler(states, t, dt, parameters):"
+        "\n"
         "\n    # Assign states"
         "\n    x = states[0]"
         "\n    z = states[1]"
@@ -246,6 +248,7 @@ def test_python_codegen_forward_explicit_euler(codegen: PythonCodeGenerator):
 def test_python_codegen_forward_generalized_rush_larsen(codegen: PythonCodeGenerator):
     assert codegen.scheme(get_scheme("forward_generalized_rush_larsen")) == (
         "def forward_generalized_rush_larsen(states, t, dt, parameters):"
+        "\n"
         "\n    # Assign states"
         "\n    x = states[0]"
         "\n    z = states[1]"
@@ -296,6 +299,7 @@ def test_python_conditional_expression(parser, trans):
     codegen = PythonCodeGenerator(ode)
     assert codegen.rhs() == (
         "def rhs(t, states, parameters):"
+        "\n"
         "\n    # Assign states"
         "\n    v = states[0]"
         "\n"
@@ -326,6 +330,7 @@ def test_python_exponential_with_power(parser, trans):
 
     assert codegen.rhs() == (
         "def rhs(t, states, parameters):"
+        "\n"
         "\n    # Assign states"
         "\n    v = states[0]"
         "\n"
@@ -347,6 +352,7 @@ def test_python_remove_unused_rhs(ode_unused):
     codegen_orig = PythonCodeGenerator(ode_unused)
     assert codegen_orig.rhs() == (
         "def rhs(t, states, parameters):"
+        "\n"
         "\n    # Assign states"
         "\n    unused_state = states[0]"
         "\n    x = states[1]"
@@ -379,6 +385,7 @@ def test_python_remove_unused_rhs(ode_unused):
     codegen_remove = PythonCodeGenerator(ode_unused, remove_unused=True)
     assert codegen_remove.rhs() == (
         "def rhs(t, states, parameters):"
+        "\n"
         "\n    # Assign states"
         "\n    x = states[1]"
         "\n    y = states[2]"
@@ -410,6 +417,7 @@ def test_python_remove_unused_forward_explicit_euler(ode_unused):
     codegen_orig = PythonCodeGenerator(ode_unused)
     assert codegen_orig.scheme(get_scheme("forward_explicit_euler")) == (
         "def forward_explicit_euler(states, t, dt, parameters):"
+        "\n"
         "\n    # Assign states"
         "\n    unused_state = states[0]"
         "\n    x = states[1]"
@@ -442,6 +450,7 @@ def test_python_remove_unused_forward_explicit_euler(ode_unused):
     codegen_remove = PythonCodeGenerator(ode_unused, remove_unused=True)
     assert codegen_remove.scheme(get_scheme("forward_explicit_euler")) == (
         "def forward_explicit_euler(states, t, dt, parameters):"
+        "\n"
         "\n    # Assign states"
         "\n    unused_state = states[0]"
         "\n    x = states[1]"
@@ -474,6 +483,7 @@ def test_python_remove_unused_forward_generalized_rush_larsen(ode_unused):
     codegen_orig = PythonCodeGenerator(ode_unused)
     assert codegen_orig.scheme(get_scheme("forward_generalized_rush_larsen")) == (
         "def forward_generalized_rush_larsen(states, t, dt, parameters):"
+        "\n"
         "\n    # Assign states"
         "\n    unused_state = states[0]"
         "\n    x = states[1]"
@@ -521,6 +531,7 @@ def test_python_remove_unused_forward_generalized_rush_larsen(ode_unused):
     codegen_remove = PythonCodeGenerator(ode_unused, remove_unused=True)
     assert codegen_remove.scheme(get_scheme("forward_generalized_rush_larsen")) == (
         "def forward_generalized_rush_larsen(states, t, dt, parameters):"
+        "\n"
         "\n    # Assign states"
         "\n    unused_state = states[0]"
         "\n    x = states[1]"
@@ -567,6 +578,7 @@ def test_python_remove_unused_forward_generalized_rush_larsen(ode_unused):
 def test_python_monitored(codegen: PythonCodeGenerator):
     assert codegen.monitor_values() == (
         "def monitor_values(t, states, parameters):"
+        "\n"
         "\n    # Assign states"
         "\n    x = states[0]"
         "\n    z = states[1]"

--- a/tests/test_subodes.py
+++ b/tests/test_subodes.py
@@ -92,7 +92,6 @@ def test_codegen_component_ode_missing_index(z_ode_codegen):
 def test_codegen_component_ode_rhs(z_ode_codegen):
     assert z_ode_codegen.rhs() == (
         "def rhs(t, states, parameters, missing_variables):"
-        "\n"
         "\n    # Assign states"
         "\n    z = states[0]"
         "\n"
@@ -118,7 +117,6 @@ def test_codegen_component_ode_rhs(z_ode_codegen):
 def test_codegen_component_ode_monitor(z_ode_codegen):
     assert z_ode_codegen.monitor_values() == (
         "def monitor_values(t, states, parameters, missing_variables):"
-        "\n"
         "\n    # Assign states"
         "\n    z = states[0]"
         "\n"
@@ -145,7 +143,6 @@ def test_codegen_component_ode_monitor(z_ode_codegen):
 def test_codegen_component_ode_fe(z_ode_codegen):
     assert z_ode_codegen.scheme(gotranx.get_scheme("forward_euler")) == (
         "def forward_euler(states, t, dt, parameters, missing_variables):"
-        "\n"
         "\n    # Assign states"
         "\n    z = states[0]"
         "\n"
@@ -207,7 +204,6 @@ def test_codegen_remaining_ode_missing_index(remaining_ode_codegen):
 def test_codegen_remaining_ode_rhs(remaining_ode_codegen):
     assert remaining_ode_codegen.rhs() == (
         "def rhs(t, states, parameters, missing_variables):"
-        "\n"
         "\n    # Assign states"
         "\n    x = states[0]"
         "\n    y = states[1]"
@@ -236,7 +232,6 @@ def test_codegen_remaining_ode_rhs(remaining_ode_codegen):
 def test_codegen_remaining_ode_generate_missing_values(remaining_ode_codegen):
     assert remaining_ode_codegen.missing_values({"x": 0, "rhoz": 1}) == (
         "def missing_values(t, states, parameters, missing_variables):"
-        "\n"
         "\n    # Assign states"
         "\n    x = states[0]"
         "\n    y = states[1]"

--- a/tests/test_subodes.py
+++ b/tests/test_subodes.py
@@ -92,6 +92,7 @@ def test_codegen_component_ode_missing_index(z_ode_codegen):
 def test_codegen_component_ode_rhs(z_ode_codegen):
     assert z_ode_codegen.rhs() == (
         "def rhs(t, states, parameters, missing_variables):"
+        "\n"
         "\n    # Assign states"
         "\n    z = states[0]"
         "\n"
@@ -117,6 +118,7 @@ def test_codegen_component_ode_rhs(z_ode_codegen):
 def test_codegen_component_ode_monitor(z_ode_codegen):
     assert z_ode_codegen.monitor_values() == (
         "def monitor_values(t, states, parameters, missing_variables):"
+        "\n"
         "\n    # Assign states"
         "\n    z = states[0]"
         "\n"
@@ -143,6 +145,7 @@ def test_codegen_component_ode_monitor(z_ode_codegen):
 def test_codegen_component_ode_fe(z_ode_codegen):
     assert z_ode_codegen.scheme(gotranx.get_scheme("forward_euler")) == (
         "def forward_euler(states, t, dt, parameters, missing_variables):"
+        "\n"
         "\n    # Assign states"
         "\n    z = states[0]"
         "\n"
@@ -204,6 +207,7 @@ def test_codegen_remaining_ode_missing_index(remaining_ode_codegen):
 def test_codegen_remaining_ode_rhs(remaining_ode_codegen):
     assert remaining_ode_codegen.rhs() == (
         "def rhs(t, states, parameters, missing_variables):"
+        "\n"
         "\n    # Assign states"
         "\n    x = states[0]"
         "\n    y = states[1]"
@@ -232,6 +236,7 @@ def test_codegen_remaining_ode_rhs(remaining_ode_codegen):
 def test_codegen_remaining_ode_generate_missing_values(remaining_ode_codegen):
     assert remaining_ode_codegen.missing_values({"x": 0, "rhoz": 1}) == (
         "def missing_values(t, states, parameters, missing_variables):"
+        "\n"
         "\n    # Assign states"
         "\n    x = states[0]"
         "\n    y = states[1]"


### PR DESCRIPTION
The main changes in this PR is the introduction of the commands `ode2py`, `ode2c` and `cellml2ode`. These are replacing the command `convert`. We do this because we need to pass different options to the different commands we decided to split them into individual commands.

Note that the `convert` command is deprecated and displays a warning, but will most likely be removed very soon.

Another addition in this PR is to add option to specify which formatter to use. For `C` we only have `clang-format` and `none`, while python has `black`, `ruff` and `none`.

We also make sure to only run the formatter once when running the cli, i.e instead of running the formatter on each function we run it only at the last stage on the full code. 

We also add the possibility to pass a config file and specify configurations in `pyproject.toml`, e.g
```toml
# pyproject

[tool.gotranx]
verbose = true
delta = 1e-6
scheme = [
    "explicit_euler",
    "generalized_rush_larsen",
    "hybrid_rush_larsen",
]
stiff_states = [
    "m",
    "h",
    "j",
]

[tool.gotranx.formatter]
c = "clang-format"
python = "black"
```

Also added a section about this in the docs