### PR TITLE
Run tests on python3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ test = [
     "pytest",
     "pytest-cov",
     "jax",
+    "cmake",
 ]
 benchmark = [
     "pytest-benchmark>=4.0.0",

--- a/src/gotranx/_enum.py
+++ b/src/gotranx/_enum.py
@@ -30,24 +30,3 @@ class OnAccess(EnumMeta):
         if isinstance(obj, Enum) and obj._on_access:
             obj._on_access()
         return obj
-
-
-class DeprecatedEnum(Enum, metaclass=OnAccess):
-    #
-    def __new__(cls, value, *args):
-        member = object.__new__(cls)
-        member._value_ = value
-        member._args = args
-        member._on_access = member.deprecate if args else None
-        return member
-
-    #
-    def deprecate(self):
-        args = (self.name,) + self._args
-        import warnings
-
-        warnings.warn(
-            "member %r is deprecated; %s" % args,
-            DeprecationWarning,
-            stacklevel=3,
-        )

--- a/src/gotranx/schemes.py
+++ b/src/gotranx/schemes.py
@@ -8,7 +8,8 @@ from structlog import get_logger
 from . import atoms
 from .ode import ODE
 from . import sympytools
-from ._enum import DeprecatedEnum
+from enum import Enum
+
 
 logger = get_logger()
 
@@ -46,14 +47,11 @@ class scheme_func(typing.Protocol):
     ) -> list[str]: ...
 
 
-class Scheme(DeprecatedEnum):
+class Scheme(str, Enum):
     explicit_euler = "explicit_euler"
     generalized_rush_larsen = "generalized_rush_larsen"
-    forward_explicit_euler = "forward_explicit_euler", "Use 'explicit_euler' instead"
-    forward_generalized_rush_larsen = (
-        "forward_generalized_rush_larsen",
-        "Use 'generalized_rush_larsen' instead",
-    )
+    forward_explicit_euler = "forward_explicit_euler"
+    forward_generalized_rush_larsen = "forward_generalized_rush_larsen"
     hybrid_rush_larsen = "hybrid_rush_larsen"
 
 
@@ -67,6 +65,15 @@ def get_scheme(scheme: str) -> scheme_func:
         func = hybrid_rush_larsen
     else:
         raise ValueError(f"Unknown scheme {scheme}")
+
+    if scheme.startswith("forward_"):
+        import warnings
+
+        warnings.warn(
+            "member %r is deprecated; %s" % (scheme, "Use the scheme without the forward prefix"),
+            DeprecationWarning,
+            stacklevel=3,
+        )
 
     # Replace the name of the function
     func.__code__ = func.__code__.replace(co_name=scheme)


### PR DESCRIPTION
Remove `DeprecatedEnum` class since it seems to be a problem with python3.12. Also add `cmake` as a dependency for running the tests since this is needed for the compile-c-extension demo.

Address https://github.com/finsberg/gotranx/issues/126