### PR TITLE
Fix weird corner case in conditional when it is not able to simplify the expression to a boolean

### DIFF
--- a/src/gotranx/codegen/base.py
+++ b/src/gotranx/codegen/base.py
@@ -87,8 +87,10 @@ def _print_Piecewise(
         else:
             return printer._print(cond)
 
-    expr = sympy.simplify(expr)
-
+    try:
+        expr = sympy.simplify(expr)
+    except TypeError:
+        logger.debug(f"Could not simplify expression {expr}")
     exprs = [printer._print(arg.expr) for arg in expr.args]
     conds = [print_cond(arg.cond) for arg in expr.args]
 

--- a/tests/test_python_codegen.py
+++ b/tests/test_python_codegen.py
@@ -824,3 +824,33 @@ def test_python_jax_codegen_initial_parameter_values(codegen_jax: JaxCodeGenerat
         "\n    return parameters"
         "\n"
     )
+
+
+def test_conditional_times_float(parser, trans):
+    expr = """ \
+    \nstates(x=0)
+    \ndx_dt = (-1.0 - x) * Conditional(Lt(x, -1.0), 1.0,0.0) \
+    """
+
+    tree = parser.parse(expr)
+    result = trans.transform(tree)
+    ode = make_ode(*result, name="name")
+    codegen = PythonCodeGenerator(ode)
+    rhs = codegen.rhs()
+    assert rhs == (
+        "def rhs(t, states, parameters):"
+        "\n"
+        "\n    # Assign states"
+        "\n    x = states[0]"
+        "\n"
+        "\n    # Assign parameters"
+        "\n"
+        "\n    # Assign expressions"
+        "\n"
+        "\n    values = numpy.zeros_like(states, dtype=numpy.float64)"
+        "\n    dx_dt = (-x - 1.0) * numpy.where((x < -1.0), 1.0, 0.0)"
+        "\n    values[0] = dx_dt"
+        "\n"
+        "\n    return values"
+        "\n"
+    )


### PR DESCRIPTION
For some reason the following expression does not work
```
states(x=0)
dx_dt = (-1.0 - x) * Conditional(Lt(x, -1.0), 1.0,0.0) 
```
However the following works fine
```
states(x=0)
dx_dt = (-1.0 - x) * Conditional(Lt(x, 1.0), 1.0,0.0) 
```
The failure happens when trying to simplify the Piecewise expression, so just adding a try except about that in case it fails.
