### PR TITLE
change type param to TYPE instead of T for Julia

### DIFF
--- a/src/gotranx/cli/__init__.py
+++ b/src/gotranx/cli/__init__.py
@@ -473,7 +473,7 @@ def ode2julia(
     type_stable: bool = typer.Option(
         False,
         "--type-stable",
-        help="Add T to the function signature",
+        help="Add TYPE to the function signature",
     ),
     # format: CFormat = typer.Option(
     #     CFormat.clang_format,

--- a/src/gotranx/cli/gotran2julia.py
+++ b/src/gotranx/cli/gotran2julia.py
@@ -43,7 +43,7 @@ def get_code(
         Stiff states, by default None. Only applicable for
         the hybrid rush larsen scheme
     type_stable : bool, optional
-        Add T to the function signature, by default False
+        Add TYPE to the function signature, by default False
 
     Returns
     -------

--- a/src/gotranx/codegen/julia.py
+++ b/src/gotranx/codegen/julia.py
@@ -24,7 +24,7 @@ class GotranJuliaCodePrinter(JuliaCodePrinter):
     def _print_Float(self, flt):
         value = str(float(flt))
         if self._type_stable:
-            return self._print(f"T({value})")
+            return self._print(f"TYPE({value})")
         return self._print(value)
 
     def _print_Piecewise(self, expr):
@@ -90,11 +90,11 @@ class JuliaCodeGenerator(CodeGenerator):
         value = RHSArgument.get_value(order)
         if self._printer._type_stable:
             argument_dict = {
-                "s": "states::AbstractVector{T}",
-                "t": "t::T",
-                "p": "parameters::AbstractVector{T}",
+                "s": "states::AbstractVector{TYPE}",
+                "t": "t::TYPE",
+                "p": "parameters::AbstractVector{TYPE}",
             }
-            values = ["values::AbstractVector{T}"]
+            values = ["values::AbstractVector{TYPE}"]
             post_function_signature = " where T"
         else:
             argument_dict = {
@@ -126,13 +126,13 @@ class JuliaCodeGenerator(CodeGenerator):
         value = SchemeArgument.get_value(order)
         if self._printer._type_stable:
             argument_dict = {
-                "s": "states::AbstractVector{T}",
-                "t": "t::T",
-                "d": "dt::T",
-                "p": "parameters::AbstractVector{T}",
+                "s": "states::AbstractVector{TYPE}",
+                "t": "t::TYPE",
+                "d": "dt::TYPE",
+                "p": "parameters::AbstractVector{TYPE}",
             }
-            values = ["values::AbstractVector{T}"]
-            post_function_signature = " where {T}"
+            values = ["values::AbstractVector{TYPE}"]
+            post_function_signature = " where {TYPE}"
         else:
             argument_dict = {
                 "s": "states",

--- a/src/gotranx/codegen/julia.py
+++ b/src/gotranx/codegen/julia.py
@@ -95,7 +95,7 @@ class JuliaCodeGenerator(CodeGenerator):
                 "p": "parameters::AbstractVector{TYPE}",
             }
             values = ["values::AbstractVector{TYPE}"]
-            post_function_signature = " where T"
+            post_function_signature = " where {TYPE}"
         else:
             argument_dict = {
                 "s": "states",

--- a/tests/test_julia_codegen.py
+++ b/tests/test_julia_codegen.py
@@ -234,7 +234,7 @@ def test_consistent_floats_with_T(parser, trans):
     codegen = JuliaCodeGenerator(ode, type_stable=True)
     rhs = codegen.rhs()
     assert rhs == (
-        "\nfunction rhs(t::T, states::AbstractVector{T}, parameters::AbstractVector{T}, values::AbstractVector{T}) where T"  # noqa: E501
+        "\nfunction rhs(t::TYPE, states::AbstractVector{TYPE}, parameters::AbstractVector{TYPE}, values::AbstractVector{TYPE}) where {TYPE}"  # noqa: E501
         "\n"
         "\n    # Assign states"
         "\n    x = states[1]"
@@ -243,7 +243,7 @@ def test_consistent_floats_with_T(parser, trans):
         "\n"
         "\n"
         "\n    # Assign expressions"
-        "\n    dx_dt = ((x >= T(31.4978)) ? (T(1.0)) : (T(1.0763) * exp((-T(1.007)) * exp((-T(0.0829)) * x))))"  # noqa: E501
+        "\n    dx_dt = ((x >= TYPE(31.4978)) ? (TYPE(1.0)) : (TYPE(1.0763) * exp((-TYPE(1.007)) * exp((-TYPE(0.0829)) * x))))"  # noqa: E501
         "\n    values[1] = dx_dt"
         "\nend"
         "\n"


### PR DESCRIPTION
I gave a little effort to trying to figure out how to scan the variable names and check if it clashes with this, but it was not obvious how to do that so for now this is at least a big improvement because a lot of these cell models use `T` as a variable.