### PR TITLE
Pin click until typer is compatible with latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "sympy",
     "typer",
     "myokit",
+    "click<8.2",
     "toml; python_version < '3.11'",
     'graphlib-backport;python_version < "3.9"',
     'typing_extensions;python_version < "3.9"',


### PR DESCRIPTION
Remove pinning when https://github.com/fastapi/typer/pull/1222 is merged