### PR TITLE
Add inline comments

### DIFF
--- a/src/gotranx/ode.lark
+++ b/src/gotranx/ode.lark
@@ -1,17 +1,21 @@
 ?start: ode
 
-?ode: (parameters | states | expressions | comment | NEWLINE) *
+ode: (parameters | states | expressions)*
+
 ?parameter: NAME "=" expression  -> param
     | NAME "=" "ScalarParam" "(" expression ["," "unit" "=" UNIT_STR] ["," "description" "=" DESCRIPTION] ")" -> scalarparam
 
 ?assignment : VARIABLE "=" expression [ comment ] [ NEWLINE ]
 
 comment : ("#" /.+/)+
-parameters : "parameters" "("  (COMPONENT_NAME ",")* parameter ("," parameter)* [ NEWLINE ] ")"
-states : "states" "("  (COMPONENT_NAME ",")* parameter ("," parameter)* [ NEWLINE ] ")"
-expressions: (assignment)+
-    | "expressions" "(" COMPONENT_NAME ("," COMPONENT_NAME)* ")" (assignment)+
-    | "component" "(" COMPONENT_NAME ("," COMPONENT_NAME)* ")" (assignment)+
+
+_param_content: parameter | "," | comment | NEWLINE
+parameters : "parameters" "("  (COMPONENT_NAME ",")* _param_content* ")"
+states : "states" "("  (COMPONENT_NAME ",")* _param_content* ")"
+
+expressions: (assignment | comment | NEWLINE)+
+    | "expressions" "(" COMPONENT_NAME ("," COMPONENT_NAME)* ")" (assignment | comment | NEWLINE)*
+    | "component" "(" COMPONENT_NAME ("," COMPONENT_NAME)* ")" (assignment | comment | NEWLINE)*
 
 
 ?expression: term (_add_op term)*

--- a/src/gotranx/transformer.py
+++ b/src/gotranx/transformer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from typing import NamedTuple
-from typing import TypeVar
+from typing import TypeVar, Any
 
 import lark
 
@@ -110,13 +110,13 @@ def find_assignments(
 
 
 def find_components(
-    s: list[None | lark.tree.Tree | lark.lexer.Token],
+    s: list[Any],
 ) -> tuple[int, tuple[str, ...]]:
     """Find components in a list
 
     Parameters
     ----------
-    s : list[None  |  lark.tree.Tree  |  lark.lexer.Token]
+    s : list[Any]
         The list
 
     Returns
@@ -142,31 +142,31 @@ def find_components(
 
 
 def lark_list_to_parameters(
-    s: list[None | lark.tree.Tree | lark.lexer.Token],
+    s: list[Any],
     cls: type[T],
-) -> tuple[T, ...]:
+) -> tuple[T | atoms.Comment, ...]:
     """Convert a list of lark trees to parameters
 
     Parameters
     ----------
-    s : list[None  |  lark.tree.Tree  |  lark.lexer.Token]
+    s : list[Any]
         The list
     cls : type[T]
         The class of the parameters
 
     Returns
     -------
-    tuple[T, ...]
-        The parameters
+    tuple[T | atoms.Comment, ...]
+        The parameters and any standalone comments
     """
     i, components = find_components(s)
-    return tuple(
-        [
-            tree2parameter(p, components=components, cls=cls)
-            for p in s[i:]
-            if isinstance(p, lark.Tree)
-        ],
-    )
+    res: list[T | atoms.Comment] = []
+    for p in s[i:]:
+        if isinstance(p, lark.Tree):
+            res.append(tree2parameter(p, components=components, cls=cls))
+        elif isinstance(p, atoms.Comment):
+            res.append(p)
+    return tuple(res)
 
 
 def tree2parameter(
@@ -262,24 +262,25 @@ class TreeToODE(lark.Transformer):
         """Convert a comment to an atoms.Comment"""
         return atoms.Comment(" ".join(map(str.lstrip, map(lambda x: x.lstrip("#"), map(str, s)))))
 
-    def states(self, s: list[None | lark.tree.Tree | lark.lexer.Token]) -> tuple[atoms.State, ...]:
+    def states(self, s: list[Any]) -> tuple[atoms.State | atoms.Comment, ...]:
         """Convert a list of states to atoms.State"""
         return lark_list_to_parameters(s, cls=atoms.State)
 
-    def parameters(
-        self, s: list[None | lark.tree.Tree | lark.lexer.Token]
-    ) -> tuple[atoms.Parameter, ...]:
+    def parameters(self, s: list[Any]) -> tuple[atoms.Parameter | atoms.Comment, ...]:
         """Convert a list of parameters to atoms.Parameter"""
         return lark_list_to_parameters(s, cls=atoms.Parameter)
 
-    def expressions(self, s) -> tuple[atoms.Assignment, ...]:
-        """Convert a list of expressions to atoms.Assignment"""
+    def expressions(self, s) -> tuple[atoms.Assignment | atoms.Comment, ...]:
+        """Convert a list of expressions to atoms.Assignment and atoms.Comment"""
         i, components = find_components(s)
 
-        assignments = []
+        assignments: list[atoms.Assignment | atoms.Comment] = []
 
         for si in s[i:]:
-            assignments.extend(find_assignments(si, components=components))
+            if isinstance(si, atoms.Comment):
+                assignments.append(si)
+            else:
+                assignments.extend(find_assignments(si, components=components))
 
         return tuple(assignments)
 
@@ -289,7 +290,7 @@ class TreeToODE(lark.Transformer):
         Parameters
         ----------
         s : list[Any]
-            List of objects that could by states, parameters or assignments
+            List of objects that could by states, parameters, assignments, or comments
 
         Returns
         -------
@@ -307,10 +308,8 @@ class TreeToODE(lark.Transformer):
             lambda: {atom: set() for atom in mapping.values()},
         )
 
-        # breakpoint()
-
         comments = []
-        for line in s:  # Each line in the block
+        for line in s:  # Each line in the block is now a tuple
             if isinstance(line, atoms.Comment):
                 comments.append(line)
                 continue
@@ -319,7 +318,11 @@ class TreeToODE(lark.Transformer):
                 # Skip empty lines
                 continue
 
-            for atom in line:  # State, Parameters or Assignment
+            for atom in line:  # State, Parameters, Assignment, or standalone Comment
+                if isinstance(atom, atoms.Comment):
+                    comments.append(atom)
+                    continue
+
                 for component in atom.components:
                     components[component][mapping[type(atom)]].add(atom)
 

--- a/tests/test_atoms.py
+++ b/tests/test_atoms.py
@@ -16,7 +16,9 @@ from gotranx.ode import gather_atoms
 def test_expression_dependencies(expr, deps, parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
-    assert result[0].value.dependencies == deps
+    # Extract the assignment from the implicitly created empty component ""
+    assignment = result.components[0].find_assignment("x")
+    assert assignment.value.dependencies == deps
 
 
 def test_parameter_arguments(parser, trans):

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1,0 +1,91 @@
+from gotranx.ode import make_ode
+
+
+def test_comment_before_and_after_equation(parser, trans):
+    expr = """
+    states(x=1.0, y=2.0)
+
+    # This is a comment before the equation
+    dx_dt = x
+    dy_dt = x - y # This is a comment after the equation
+    """
+    tree = parser.parse(expr)
+    ode = make_ode(*trans.transform(tree))
+
+    assert ode.num_states == 2
+    assert ode.num_components == 1
+
+    dx_dt = ode.get_component("").find_assignment("dx_dt")
+    assert dx_dt.comment is None
+
+    dy_dt = ode.get_component("").find_assignment("dy_dt")
+    assert dy_dt.comment.text == "This is a comment after the equation"
+
+
+def test_comments_inside_expressions_block(parser, trans):
+    expr = """
+    states("My component", x=1.0)
+    expressions("My component")
+    # Comment A
+    dx_dt = x # Comment B
+    # Comment C
+    """
+    tree = parser.parse(expr)
+    ode = make_ode(*trans.transform(tree))
+
+    assert ode.num_states == 1
+    dx_dt = ode.get_component("My component").find_assignment("dx_dt")
+    assert dx_dt.comment.text == "Comment B"
+
+
+def test_comments_in_parameters_and_states(parser, trans):
+    expr = """
+    parameters(
+        # Comment P1
+        a=0,
+        # Comment P2
+        b=1 # Comment P3
+        # Comment P4
+    )
+    states(
+        # Comment S1
+        x=1.0, # Comment S2
+        # Comment S3
+        y=2.0
+        # Comment S4
+    )
+    dx_dt = a
+    dy_dt = b
+    """
+    tree = parser.parse(expr)
+    ode = make_ode(*trans.transform(tree))
+
+    assert ode.num_parameters == 2
+    assert ode.num_states == 2
+
+    # Check that parameters were parsed correctly
+    a = ode.get_component("").find_parameter("a")
+    b = ode.get_component("").find_parameter("b")
+    assert a.value == 0
+    assert b.value == 1
+
+
+def test_only_comments_in_block(parser, trans):
+    expr = """
+    expressions("My component")
+    # Just a comment here
+
+    parameters(
+        # And here
+    )
+
+    states("My component",
+        # State comments
+    )
+    """
+    tree = parser.parse(expr)
+    ode = make_ode(*trans.transform(tree))
+
+    assert ode.num_states == 0
+    assert ode.num_parameters == 0
+    assert ode.num_components == 0

--- a/tests/test_conditionals.py
+++ b/tests/test_conditionals.py
@@ -23,8 +23,11 @@ def test_Conditional_expr(expr, expected, parser, trans):
     time = sp.Symbol("time")
     tree = parser.parse(expr)
     result = trans.transform(tree)
-    assert len(result) == 1
-    sympy_expr = build_expression(result[0].value.tree, symbols={"time": time})
+    assert len(result.components[0].assignments) == 1
+
+    assignment = result.components[0].find_assignment("x")
+    sympy_expr = build_expression(assignment.value.tree, symbols={"time": time})
+
     assert sympy_expr.subs({"time": 0}) == expected[0]
     assert sympy_expr.subs({"time": 1}) == expected[1]
     assert sympy_expr.subs({"time": -1}) == expected[2]

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -17,9 +17,12 @@ from gotranx.expressions import build_expression
 def test_build_expression(expr, symbol_values, expected, parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
+    components = result.components[0]
+    assignment = components.find_assignment("x")
 
     symbols = {name: sp.Symbol(name) for name in symbol_values}
-    value = result[0].value.tree
+
+    value = assignment.value.tree
     sympy_expr = build_expression(value, symbols)
 
     assert sympy_expr.subs(symbol_values).evalf() == pytest.approx(expected)
@@ -104,6 +107,8 @@ def test_expression_missing_symbol(parser, trans):
     expr = "x = a + 1"
     tree = parser.parse(expr)
     result = trans.transform(tree)
+    components = result.components[0]
+    assignment = components.find_assignment("x")
     with pytest.raises(gotranx.expressions.MissingSymbolError) as e:
-        build_expression(result[0].value.tree, symbols={})
+        build_expression(assignment.value.tree, symbols={})
     assert str(e.value) == "Symbol 'a' not found in line 1"

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 from gotranx.load import load_ode, ode_from_string
-from gotranx.exceptions import ODEFileNotFound, InvalidODEException, ComponentNotCompleteError
+from gotranx.exceptions import ODEFileNotFound, ComponentNotCompleteError
 
 
 @pytest.fixture
@@ -54,7 +54,7 @@ def test_load_ode(path):
 
 
 def test_load_invalid_ode():
-    with pytest.raises(InvalidODEException):
+    with pytest.raises(ComponentNotCompleteError):
         ode_from_string("states(x=1)")
 
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -53,6 +53,8 @@ from gotranx.expressions import build_expression
 def test_operations(expr, expected, parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
-    assert len(result) == 1
-    sympy_expr = build_expression(result[0].value.tree)
+    assignments = result.components[0].assignments
+    assert len(assignments) == 1
+    assignment = list(assignments)[0]
+    sympy_expr = build_expression(assignment.value.tree)
     assert math.isclose(float(sympy_expr), expected)

--- a/tests/test_transformer_assignments.py
+++ b/tests/test_transformer_assignments.py
@@ -11,10 +11,11 @@ from gotranx.units import ureg
 @pytest.mark.parametrize("expr", ["x=1", "x = 1", "x= 1"])
 def test_assignment_single_1(expr, parser, trans):
     tree = parser.parse(expr)
-    result = trans.transform(tree)
+    result = trans.transform(tree).components[0].assignments
     assert len(result) == 1
-    assert result[0].name == "x"
-    assert result[0].value.tree == lark.Tree(
+    assignment = list(result)[0]
+    assert assignment.name == "x"
+    assert assignment.value.tree == lark.Tree(
         "scientific",
         [lark.Token("SCIENTIFIC_NUMBER", "1")],
     )
@@ -30,10 +31,11 @@ def test_assignment_single_1(expr, parser, trans):
 )
 def test_assignment_single_2_terms(expr, parser, trans):
     tree = parser.parse(expr)
-    result = trans.transform(tree)
+    result = trans.transform(tree).components[0].assignments
     assert len(result) == 1
-    assert result[0].name == "x"
-    assert result[0].value.tree == lark.Tree(
+    assignment = list(result)[0]
+    assert assignment.name == "x"
+    assert assignment.value.tree == lark.Tree(
         lark.Token("RULE", "expression"),
         [
             lark.Tree(lark.Token("RULE", "scientific"), [lark.Token("SCIENTIFIC_NUMBER", "1")]),
@@ -45,10 +47,11 @@ def test_assignment_single_2_terms(expr, parser, trans):
 
 def test_assignment_single_3_terms(parser, trans):
     tree = parser.parse("x = 1 * 2 + 3")
-    result = trans.transform(tree)
+    result = trans.transform(tree).components[0].assignments
     assert len(result) == 1
-    assert result[0].name == "x"
-    assert result[0].value.tree == lark.Tree(
+    assignment = list(result)[0]
+    assert assignment.name == "x"
+    assert assignment.value.tree == lark.Tree(
         lark.Token("RULE", "expression"),
         [
             lark.Tree(
@@ -73,11 +76,11 @@ def test_assignment_single_3_terms(parser, trans):
 
 def test_assignment_single_4_terms(parser, trans):
     tree = parser.parse("x = 1 * 2 + 3 - 4")
-    result = trans.transform(tree)
+    result = trans.transform(tree).components[0].assignments
     assert len(result) == 1
-
-    assert result[0].name == "x"
-    assert result[0].value.tree == lark.Tree(
+    assignment = list(result)[0]
+    assert assignment.name == "x"
+    assert assignment.value.tree == lark.Tree(
         lark.Token("RULE", "expression"),
         [
             lark.Tree(
@@ -112,10 +115,11 @@ def test_assignment_single_4_terms(parser, trans):
 )
 def test_assignment_single5(expr, parser, trans):
     tree = parser.parse(expr)
-    result = trans.transform(tree)
+    result = trans.transform(tree).components[0].assignments
     assert len(result) == 1
-    assert result[0].name == "x"
-    assert result[0].value.tree == lark.Tree(
+    assignment = list(result)[0]
+    assert assignment.name == "x"
+    assert assignment.value.tree == lark.Tree(
         lark.Token("RULE", "expression"),
         [
             lark.Tree(
@@ -156,10 +160,11 @@ def test_assignment_single5(expr, parser, trans):
 def test_assignment_single_with_names(parser, trans):
     expr = "x = (1 * y) + rho - (z / sigma)"
     tree = parser.parse(expr)
-    result = trans.transform(tree)
+    result = trans.transform(tree).components[0].assignments
     assert len(result) == 1
-    assert result[0].name == "x"
-    assert result[0].value.tree == lark.Tree(
+    assignment = list(result)[0]
+    assert assignment.name == "x"
+    assert assignment.value.tree == lark.Tree(
         lark.Token("RULE", "expression"),
         [
             lark.Tree(
@@ -195,14 +200,15 @@ def test_assignment_single_with_names(parser, trans):
 def test_assignment_double(expr, parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
-    assert len(result) == 2
-    assert result[0].name == "x"
-    assert result[0].value.tree == lark.Tree(
+    assignments = sorted(result.components[0].assignments, key=lambda x: x.name)
+    assert len(assignments) == 2
+    assert assignments[0].name == "x"
+    assert assignments[0].value.tree == lark.Tree(
         "scientific",
         [lark.Token("SCIENTIFIC_NUMBER", "1")],
     )
-    assert result[1].name == "y"
-    assert result[1].value.tree == lark.Tree(
+    assert assignments[1].name == "y"
+    assert assignments[1].value.tree == lark.Tree(
         "scientific",
         [lark.Token("SCIENTIFIC_NUMBER", "2")],
     )
@@ -280,9 +286,6 @@ def test_expressions_with_name_and_unit(parser, trans):
     x = 1  # mV
     y = 2  # mol
     """
-    tree = parser.parse(expr)
-    result = trans.transform(tree)
-
     tree = parser.parse(expr)
     result = trans.transform(tree)
 
@@ -385,7 +388,8 @@ def test_expression_functions(expr, subs, expected, parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
     symbols = {name: sp.Symbol(name) for name in subs}
-    sympy_expr = build_expression(result[0].value.tree, symbols=symbols)
+    assignment = list(result.components[0].assignments)[0]
+    sympy_expr = build_expression(assignment.value.tree, symbols=symbols)
     assert math.isclose(sympy_expr.subs(subs), expected)
 
 
@@ -454,9 +458,7 @@ def test_expressions_scientific_notation(expr, expected, parser, trans):
 def test_assignment_with_unit(expr, unit, parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
-    # Since expression don't start with a newline we get
-    # an Assignment object
-    x = result[0]
+    x = list(result.components[0].assignments)[0]
     assert x.unit == unit
 
 
@@ -489,7 +491,7 @@ def test_lt_gt_conditional(expr, subs, expected, parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
     symbols = {name: sp.Symbol(name) for name in subs}
-    alpha_h = result[0]
+    alpha_h = list(result.components[0].assignments)[0]
     sympy_expr = build_expression(alpha_h.value.tree, symbols=symbols)
 
     assert math.isclose(sympy_expr.subs(subs), expected)

--- a/tests/test_transformer_parameters.py
+++ b/tests/test_transformer_parameters.py
@@ -18,8 +18,9 @@ from gotranx import atoms
 def test_parameters_single(expr, parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
-    assert len(result) == 1
-    assert result[0] == atoms.Parameter(name="x", value=1)
+    parameters = list(result.components[0].parameters)
+    assert len(parameters) == 1
+    assert parameters[0] == atoms.Parameter(name="x", value=1)
 
 
 @pytest.mark.parametrize(
@@ -39,18 +40,20 @@ def test_parameters_single(expr, parser, trans):
 def test_parameters_double(expr, parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
-    assert len(result) == 2
-    assert result[0] == atoms.Parameter(name="x", value=1)
-    assert result[1] == atoms.Parameter(name="y", value=2)
+    parameters = sorted(result.components[0].parameters, key=lambda x: x.name)
+    assert len(parameters) == 2
+    assert parameters[0] == atoms.Parameter(name="x", value=1)
+    assert parameters[1] == atoms.Parameter(name="y", value=2)
 
 
 def test_parameters_with_component(parser, trans):
     expr = 'parameters("My Component", x=1, y=2)'
     tree = parser.parse(expr)
     result = trans.transform(tree)
-    assert len(result) == 2
-    assert result[0] == atoms.Parameter(name="x", value=1, components=("My Component",))
-    assert result[1] == atoms.Parameter(name="y", value=2, components=("My Component",))
+    parameters = sorted(result.components[0].parameters, key=lambda x: x.name)
+    assert len(parameters) == 2
+    assert parameters[0] == atoms.Parameter(name="x", value=1, components=("My Component",))
+    assert parameters[1] == atoms.Parameter(name="y", value=2, components=("My Component",))
 
 
 def test_different_sets_of_parameters(parser, trans):
@@ -136,4 +139,5 @@ def test_different_sets_of_parameters(parser, trans):
 def test_parameter_with_unit_and_desc(expr, expected, parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
-    assert result == expected
+    parameters = tuple(sorted(result.components[0].parameters, key=lambda x: x.name))
+    assert parameters == expected

--- a/tests/test_transformer_states.py
+++ b/tests/test_transformer_states.py
@@ -18,8 +18,9 @@ from gotranx import atoms
 def test_states_single(expr, parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
-    assert len(result) == 1
-    assert result[0] == atoms.State(name="x", value=1)
+    states = list(result.components[0].states)
+    assert len(states) == 1
+    assert states[0] == atoms.State(name="x", value=1)
 
 
 @pytest.mark.parametrize(
@@ -39,31 +40,29 @@ def test_states_single(expr, parser, trans):
 def test_states_double(expr, parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
-    assert len(result) == 2
-
-    assert result[0] == atoms.State(name="x", value=1)
-    assert result[1] == atoms.State(name="y", value=2)
+    states = sorted(result.components[0].states, key=lambda x: x.name)
+    assert len(states) == 2
+    assert states[0] == atoms.State(name="x", value=1)
+    assert states[1] == atoms.State(name="y", value=2)
 
 
 def test_states_with_component(parser, trans):
     expr = 'states("My component", x=1, y=2)'
     tree = parser.parse(expr)
     result = trans.transform(tree)
-
-    assert len(result) == 2
-
-    assert result[0] == atoms.State(name="x", value=1, components=("My component",))
-    assert result[1] == atoms.State(name="y", value=2, components=("My component",))
+    states = sorted(result.components[0].states, key=lambda x: x.name)
+    assert len(states) == 2
+    assert states[0] == atoms.State(name="x", value=1, components=("My component",))
+    assert states[1] == atoms.State(name="y", value=2, components=("My component",))
 
 
 def test_states_with_component_and_info(parser, trans):
     expr = 'states("My component", "Some info about the component", x=1, y=2)'
     tree = parser.parse(expr)
     result = trans.transform(tree)
-
-    assert len(result) == 2
-
-    assert result[0] == atoms.State(
+    states = sorted(result.components[0].states, key=lambda x: x.name)
+    assert len(states) == 2
+    assert states[0] == atoms.State(
         name="x",
         value=1,
         components=(
@@ -71,7 +70,7 @@ def test_states_with_component_and_info(parser, trans):
             "Some info about the component",
         ),
     )
-    assert result[1] == atoms.State(
+    assert states[1] == atoms.State(
         name="y",
         value=2,
         components=(
@@ -180,4 +179,5 @@ def test_different_sets_of_states(parser, trans):
 def test_states_with_unit_and_desc(expr, expected, parser, trans):
     tree = parser.parse(expr)
     result = trans.transform(tree)
-    assert result == expected
+    states = tuple(sorted(result.components[0].states, key=lambda x: x.name))
+    assert states == expected


### PR DESCRIPTION
Add possibility to add inline comments in ode file, both on a separate line within expressions, parameters and states as well as after expressions. 

As a result of this change we also did a refactoring for the parser so that the parsed results is now always a LarkODE.