### PR TITLE
Less xreplace

### DIFF
--- a/src/gotranx/myokit.py
+++ b/src/gotranx/myokit.py
@@ -429,14 +429,24 @@ def gotran_to_myokit(ode: ODE, time_component="engine", time_unit="s") -> "myoki
             state = state_derivative.state
             v = comp[state.name]
 
-            expr = state_derivative.expr.xreplace(global_var_map)
+            # xreplace() rebuilds any node containing a substituted symbol
+            # using the default (evaluate=True) constructor unless told
+            # otherwise - without this, sympy auto-distributes numeric
+            # coefficients over sums (e.g. (v - 4.823)/51.12 turns into
+            # 0.0195618153364632*v - 0.0943466353677621), silently
+            # rewriting the user's expression into a numerically equivalent
+            # but far less readable (and needlessly floating-point-heavy)
+            # form.
+            with sp.core.parameters.evaluate(False):
+                expr = state_derivative.expr.xreplace(global_var_map)
             expr = sympy_reader.ex(expr)
             v.set_rhs(expr)
             v.promote(state.value)
 
         for intermediate in component.intermediates:
             v = comp[intermediate.name]
-            expr = intermediate.expr.xreplace(global_var_map)
+            with sp.core.parameters.evaluate(False):
+                expr = intermediate.expr.xreplace(global_var_map)
             expr = sympy_reader.ex(expr)
             v.set_rhs(expr)
 

--- a/src/gotranx/myokit.py
+++ b/src/gotranx/myokit.py
@@ -172,6 +172,44 @@ def extract_nested_variables(
     return all_subs, component_subs
 
 
+def _normalize_integer_powers(expr: sp.Expr) -> sp.Expr:
+    """Replace float exponents that represent an integer with that integer
+
+    myokit's sympy writer (``myokit.formats.sympy.write``) represents
+    e.g. ``1/x`` as ``x**Float(-1.0)`` rather than the sympy convention of
+    an integer exponent (``x**Integer(-1)``). Because the exponent is a
+    ``Float`` rather than an ``Integer``, sympy's printer can't recognize it
+    as a reciprocal or drop a redundant power of 1, so expressions print as
+    e.g. ``1.0/x**1.0`` instead of ``1/x``, or ``x**1.0`` instead of ``x``.
+
+    Parameters
+    ----------
+    expr : sp.Expr
+        The expression to normalize
+
+    Returns
+    -------
+    sp.Expr
+        The expression with integer-valued float exponents replaced by
+        integer exponents (and powers of 1 dropped entirely)
+    """
+
+    def fix_power(power: sp.Pow) -> sp.Expr:
+        base: sp.Expr = power.base
+        exponent: sp.Expr = power.exp
+        # sympy's Float and Integer are not `==`-equal even when numerically
+        # identical (a Float carries finite precision, an Integer is exact),
+        # so integer-valued floats must be detected via plain float/int
+        # comparison rather than sympy's own equality.
+        if exponent.is_Float and float(exponent) == int(exponent):
+            exponent = sp.Integer(int(exponent))
+        if exponent == 1:
+            return base
+        return sp.Pow(base, exponent, evaluate=False)
+
+    return sp.sympify(expr.replace(lambda e: e.is_Pow, fix_power))
+
+
 def mmt_to_gotran(filename: str | Path) -> ODE:
     """Convert a myokit model to gotran ODE
 
@@ -244,6 +282,7 @@ def myokit_to_gotran(model: "myokit.Model", protocol=None) -> ODE:
                 states.append(state)
                 with sp.core.parameters.evaluate(False):
                     expr = myokit.formats.sympy.write(var.eq().rhs)
+                    expr = _normalize_integer_powers(expr)
                     expr = expr.xreplace({v.name(): v.uname() for v in var.variables(deep=True)})
                     expr = expr.xreplace(component_subs.get(component.name(), {}))
                     expr = expr.xreplace(all_subs)
@@ -262,6 +301,7 @@ def myokit_to_gotran(model: "myokit.Model", protocol=None) -> ODE:
             else:
                 with sp.core.parameters.evaluate(False):
                     expr = myokit.formats.sympy.write(var.rhs())
+                    expr = _normalize_integer_powers(expr)
                 if expr.is_Number:
                     parameter = atoms.Parameter(
                         name=name,

--- a/src/gotranx/sympytools.py
+++ b/src/gotranx/sympytools.py
@@ -43,7 +43,14 @@ def rhs_matrix(ode, max_tries: int = 20) -> sympy.Matrix:
 
     num_tries = 0
     while (any([rhs.has(k) for k in intermediates.keys()])) and num_tries < max_tries:
-        rhs = rhs.xreplace(intermediates)
+        # xreplace() rebuilds every ancestor of a substituted symbol using the
+        # default (evaluate=True) constructor, which auto-distributes numeric
+        # coefficients over sums - e.g. (x - 4.823)/51.12 would silently
+        # become 0.0195618153364632*x - 0.0943466353677621 if an intermediate
+        # substituted here happens to sit inside such a division. Matches the
+        # same fix applied in myokit.gotran_to_myokit.
+        with sympy.core.parameters.evaluate(False):
+            rhs = rhs.xreplace(intermediates)
         num_tries += 1
 
     if num_tries == max_tries:

--- a/tests/test_myokit.py
+++ b/tests/test_myokit.py
@@ -107,6 +107,36 @@ def test_gotran_to_myokit_cross_component_reference():
 
 
 @pytest.mark.skipif(myokit is None, reason="myokit not installed")
+def test_gotran_to_myokit_does_not_distribute_coefficients():
+    # gotran_to_myokit substitutes local symbol names for their fully
+    # qualified myokit.qname() equivalent via xreplace(). Without wrapping
+    # that call in `with sp.core.parameters.evaluate(False)`, sympy rebuilds
+    # every ancestor of a substituted symbol using its default (evaluate=True)
+    # constructor, which auto-distributes numeric coefficients over sums -
+    # e.g. (v - 4.823)/51.12 silently became 0.0195618153364632*v -
+    # 0.0943466353677621. This must not happen: the qualified expression
+    # should have the same *structure* as the original, just with `v`
+    # replaced by `membrane.v`.
+    ode = gotranx.load.ode_from_string(
+        """
+        states("membrane", v=-91.33918)
+        expressions("membrane")
+        dv_dt = -v
+        expressions("other")
+        tm = 0.06487*exp(-((v - 1*4.823)/51.12)**2)
+        """
+    )
+    myokit_model = gotranx.myokit.gotran_to_myokit(ode)
+    tm = myokit_model.get("other.tm")
+    code = tm.rhs().code()
+    assert "membrane.v" in code
+    # The distributed form would contain a decimal coefficient in front of
+    # membrane.v (e.g. "1.95618...e-2 * membrane.v"); the un-distributed
+    # form keeps "membrane.v" appearing on its own next to the literal 51.12.
+    assert "51.12" in code
+
+
+@pytest.mark.skipif(myokit is None, reason="myokit not installed")
 @pytest.mark.parametrize(
     "component_name",
     ["", "My component", "environment"],

--- a/tests/test_myokit.py
+++ b/tests/test_myokit.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import math
 import pytest
+import sympy as sp
 import gotranx.myokit
 
 try:
@@ -124,3 +125,52 @@ def test_gotran_to_myokit_sanitizes_component_names(component_name):
 
     myokit_model = gotranx.myokit.gotran_to_myokit(ode)
     myokit_model.validate()
+
+
+def _pow_unevaluated(base, exponent):
+    # Build a Pow node the same way myokit.formats.sympy.write() does: with
+    # evaluate=False, so Python/sympy never gets a chance to auto-simplify
+    # the exponent (e.g. collapsing a double reciprocal) before our own
+    # normalization runs.
+    with sp.core.parameters.evaluate(False):
+        return sp.Pow(base, exponent, evaluate=False)
+
+
+@pytest.mark.skipif(myokit is None, reason="myokit not installed")
+@pytest.mark.parametrize(
+    "expr, expected",
+    [
+        # myokit's sympy writer represents 1/x as x**Float(-1.0), which the
+        # sympy printer can't recognize as a reciprocal (unlike x**Integer(-1)),
+        # so it used to print as "1.0/x**1.0" instead of "1.0/x".
+        (
+            sp.Mul(sp.Float(1.0), _pow_unevaluated(sp.Symbol("x"), sp.Float(-1.0)), evaluate=False),
+            "1.0/x",
+        ),
+        # A bare power of 1.0 should collapse to just the base.
+        (_pow_unevaluated(sp.Symbol("x"), sp.Float(1.0)), "x"),
+        # Integer-valued float exponents elsewhere should become clean integers.
+        (_pow_unevaluated(sp.Symbol("x"), sp.Float(4.0)), "x**4"),
+        # Non-integer exponents must be left untouched.
+        (_pow_unevaluated(sp.Symbol("x"), sp.Float(1.5)), "x**1.5"),
+    ],
+)
+def test_normalize_integer_powers(expr, expected):
+    normalized = gotranx.myokit._normalize_integer_powers(expr)
+    assert str(normalized) == expected
+
+
+@pytest.mark.skipif(myokit is None, reason="myokit not installed")
+def test_cellml_to_gotran_has_no_redundant_float_powers(tmp_path):
+    # Regression test: myokit's sympy writer used to leave expressions such
+    # as divisions (1/x) with a *float* exponent (x**-1.0 rather than
+    # x**-1), which the sympy printer renders as "1.0/x**1.0" - a redundant
+    # "**1.0" that should never appear in generated .ode files.
+    ode = gotranx.myokit.cellml_to_gotran(
+        filename=here / "cellml_files" / "ToRORd_dynCl_mid.cellml",
+    )
+    out_odefile = tmp_path / "ToRORd_dynCl_mid.ode"
+    ode.save(out_odefile)
+    text = out_odefile.read_text()
+    assert "**1.0" not in text
+    assert "**-1.0" not in text

--- a/tests/test_sympytools.py
+++ b/tests/test_sympytools.py
@@ -62,6 +62,26 @@ def test_rhs_matrix(ode: ODE):
     assert str(rhs[2]) == "(-beta)*z + x*y"
 
 
+def test_rhs_matrix_does_not_distribute_coefficients(trans, parser):
+    # rhs_matrix eliminates intermediates via xreplace(). Without wrapping
+    # that call in `with sympy.core.parameters.evaluate(False)`, sympy
+    # rebuilds every ancestor of a substituted symbol using the default
+    # (evaluate=True) constructor, which auto-distributes numeric
+    # coefficients over sums - e.g. (tm - 4.823)/51.12 would silently
+    # become 0.0195618153364632*tm - 0.0943466353677621 once tm is
+    # substituted with an expression containing v. Matches the same fix
+    # applied in myokit.gotran_to_myokit.
+    expr = """
+    states(v=-91.33918)
+    dv_dt = (tm - 1*4.823)/51.12
+    tm = v
+    """
+    tree = parser.parse(expr)
+    ode = make_ode(*trans.transform(tree))
+    rhs = sympytools.rhs_matrix(ode)
+    assert str(rhs[0]) == "(v - 4.823)/51.12"
+
+
 def test_jacobian_matrix(ode: ODE):
     jac = sympytools.jacobi_matrix(ode)
 


### PR DESCRIPTION
Carry over more of the underlying expression. Until now for example the expression 
```
(v - 4.823)/51.12
```
will silently be turned into 
```
0.0195618153364632*v - 0.0943466353677621
```
Now, the full expression is carried through the code generation which will hopefully improve the precision.
This is achieved using the context manager
```python
with sp.core.parameters.evaluate(False):
     ....
```
when using `xreplace`.

Also remove expressions such as `*1.0` and `/1.0`